### PR TITLE
Fixed HTTP Port Mapping - All HTTP requests work on Port 80

### DIFF
--- a/intern-nginx/nginx.conf
+++ b/intern-nginx/nginx.conf
@@ -17,7 +17,7 @@ http {
     default_type  application/octet-stream;
 
     log_format backend '$remote_addr - $remote_user [$time_local] "$request" '
-                       'status=$status backend_ip=$backend_ip backend_port=$backend_port '
+                       'status=$status backend_ip=$backend_ip backend_port=80 '
                        '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
 
     access_log /var/log/nginx/access.log backend;

--- a/intern-nginx/reverse_proxy.conf
+++ b/intern-nginx/reverse_proxy.conf
@@ -1,13 +1,11 @@
-# /etc/nginx/conf.d/reverse_proxy.conf
 js_import port_module from /etc/nginx/port_map.js;
 js_set $backend_ip port_module.ipLookup;
-js_set $backend_port port_module.portLookup;
 
 # Define a custom log format
 log_format proxy_log '$remote_addr - $host [$time_local] '
                      '"$request" $status $body_bytes_sent '
                      '"$http_referer" "$http_user_agent" '
-                     'to $backend_ip:$backend_port';
+                     'to $backend_ip:80';
 
 # Enable access and error logs
 access_log /var/log/nginx/reverse_proxy_access.log proxy_log;
@@ -20,13 +18,9 @@ server {
     location / {
         if ($backend_ip = "") {
             return 404 "Backend IP not found.";
-        }
+        }       
 
-        if ($backend_port = "") {
-            return 404 "Backend port not found.";
-        }
-
-        proxy_pass http://$backend_ip:$backend_port;
+        proxy_pass http://$backend_ip:80;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
All container HTTP requests (ie. test-container.opensource.mieweb.com:80) are able to use port 80 instead of unique HTTP ports. Updated the nginx reverse proxy configuration file to proxy pass to $backend_ip:80 instead of $backend_ip:$backend_port. Updated all associated logging, too.