### PR TITLE
fix: include PHXDC-ai-pve1 in PVE_NODES for prune_iptables.sh

### DIFF
--- a/gateway/prune_iptables.sh
+++ b/gateway/prune_iptables.sh
@@ -15,7 +15,7 @@ REMOTE_HOST="intern-nginx"
 REMOTE_FILE="/etc/nginx/port_map.json"
 LOCAL_FILE="/tmp/port_map.json"
 LOG_FILE="/var/log/prune_iptables.log"
-PVE_NODES=("localhost" "10.15.0.5")
+PVE_NODES=("localhost" "10.15.0.5" "10.15.0.6")
 
 # Function to log messages with a timestamp
 log_message() {


### PR DESCRIPTION
Summary:
This PR updates the prune_iptables.sh script to include the PHXDC-ai-pve1 server in the PVE_NODES array. This ensures that containers running on PHXDC-ai-pve1 are considered when pruning port mappings, preventing accidental removal of valid port configurations from /etc/nginx/port_map.json.

Impact:

Prevents loss of port mappings for containers on PHXDC-ai-pve1.
Ensures correct connectivity and access for all relevant containers.
Closes: #31