### PR TITLE
add cluster.mieweb.org internal domain

### DIFF
--- a/dnsmasq-service/dnsmasq.conf
+++ b/dnsmasq-service/dnsmasq.conf
@@ -1,8 +1,7 @@
 # /etc/dnsmasq.conf
 
 # Domain and interface
-domain=opensource.mieweb.org
-domain=opensource.mieweb.com
+domain=cluster.mieweb.org
 interface=eth0
 listen-address=127.0.0.1,10.15.0.3
 server=8.8.8.8


### PR DESCRIPTION
Resolves unqualified container names or container names with `.cluster.mieweb.org` as the domain part to their IP address. Still resolves `*.opensource.mieweb.org` to the Load Balancer for SSL handling.

Example of it working:

```
rgingras@create-a-container-dev:~/opensource-server$ host create-a-container
create-a-container.cluster.mieweb.org has address 10.15.221.118
rgingras@create-a-container-dev:~/opensource-server$ host create-a-container.opensource.mieweb.org
create-a-container.opensource.mieweb.org has address 10.15.20.69
rgingras@create-a-container-dev:~/opensource-server$ host create-a-container.opensource.mieweb.com
create-a-container.opensource.mieweb.com has address 10.15.20.69
create-a-container.opensource.mieweb.com is an alias for opensource.mieweb.com.
create-a-container.opensource.mieweb.com is an alias for opensource.mieweb.com.
```

Remaining issue: statically allocated IP addresses, such as for the Proxmoxes and the default gateway still do not resolve on the `cluster` subdomain. Possible solution includes a static /etc/dnsmasq.d/hosts file with the mapping, but that's not portable.