### PR TITLE
Add styles for sign up button and section

### DIFF
--- a/create-a-container/public/style.css
+++ b/create-a-container/public/style.css
@@ -192,3 +192,42 @@ select:focus {
 .navbar .logout-button:hover {
     background-color: #c0392b;
 }
+
+#signUpBtn {
+    width: 100%;
+    padding: 0.8rem;
+    background-color: #3498db;
+    border: none;
+    border-radius: 6px;
+    color: white;
+    font-weight: bold;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: background-color 0.3s;
+}
+
+#signUpBtn:hover {
+    background-color: #2980b9;
+}
+
+#signUpBtn {
+    width: 100%;
+    padding: 0.8rem;
+    background-color: #3498db;
+    border: none;
+    border-radius: 6px;
+    color: white;
+    font-weight: bold;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: background-color 0.3s;
+}
+
+#signUpBtn:hover {
+    background-color: #2980b9;
+}
+
+.signup-section {
+    margin-top: 1.5rem;
+}
+


### PR DESCRIPTION
Added CSS rules for #signUpBtn and .signup-section to style the sign up button and provide spacing for the sign up section. Includes hover effects and button appearance enhancements. Keeping the back to login button the same to keep it distinct from the actual request. 

Fixes https://github.com/mieweb/opensource-server/issues/75

<img width="488" height="582" alt="image" src="https://github.com/user-attachments/assets/71c7c5de-05e1-410d-aec5-d478b47cc229" />

<img width="485" height="725" alt="image" src="https://github.com/user-attachments/assets/4225c610-b2d8-48dc-84e1-c2d7908f05b4" />

