### PR TITLE
refactor: update DHCP range and options in dnsmasq configuration

### DIFF
--- a/dnsmasq-service/dnsmasq.conf
+++ b/dnsmasq-service/dnsmasq.conf
@@ -7,7 +7,8 @@ listen-address=127.0.0.1,10.15.0.3
 server=8.8.8.8
 
 # DHCP range
-dhcp-range=10.15.0.10,10.15.254.254,255.255.0.0,24h
+dhcp-range=set:net15,10.15.0.10,10.15.254.254,255.255.0.0,24h
+dhcp-range=set:net16,10.16.0.10,10.16.254.254,255.255.0.0,24h
 
 # Static reservations (MAC optional, just use hostname mapping for now)
 dhcp-host=ct100,10.15.0.100,infinite
@@ -15,7 +16,8 @@ dhcp-host=ct101,10.15.0.101,infinite
 
 # DHCP options
 dhcp-authoritative
-dhcp-option=option:router,10.15.0.1
+dhcp-option=tag:net15,option:router,10.15.0.1
+dhcp-option=tag:net16,option:router,10.16.0.1
 dhcp-option=option:dns-server,10.15.0.3  # dnsmasq itself is the DNS server
 
 # DNS handling


### PR DESCRIPTION
This pull request updates the DHCP configuration in `dnsmasq.conf` to support multiple network ranges and assign router options based on network tags. The main changes are the addition of a new DHCP range for a second subnet and the use of tags to specify router options per subnet.

**DHCP configuration enhancements:**

* Added a new DHCP range for the `10.16.0.0/16` subnet with the tag `net16`, alongside the existing `10.15.0.0/16` range now tagged as `net15`.
* Updated DHCP router options to use tags, so that devices in `net15` receive `10.15.0.1` as their router and devices in `net16` receive `10.16.0.1`.