### PR TITLE
add fortwayne-proxmox configuration for SSL and proxy settings

### DIFF
--- a/nginx-reverse-proxy/conf.d/fortwayne-proxmox.conf
+++ b/nginx-reverse-proxy/conf.d/fortwayne-proxmox.conf
@@ -1,0 +1,68 @@
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  listen 443 quic;
+  listen [::]:443 quic;
+  http2 on;
+  http3 on;
+
+  server_name fortwayne-proxmox.opensource.mieweb.org;
+
+  # SSL certificates
+  ssl_certificate /root/.acme.sh/opensource.mieweb.org/fullchain.cer;
+  ssl_certificate_key /root/.acme.sh/opensource.mieweb.org/opensource.mieweb.org.key;
+
+  # Modern TLS configuration
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
+  ssl_prefer_server_ciphers off;
+
+  # SSL session optimization
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_timeout 10m;
+  ssl_session_tickets off;
+
+  # OCSP stapling
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  ssl_trusted_certificate /root/.acme.sh/opensource.mieweb.org/fullchain.cer;
+  resolver 1.1.1.1 8.8.8.8 valid=300s;
+  resolver_timeout 5s;
+
+  # Security headers
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+  add_header X-Frame-Options "SAMEORIGIN" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-XSS-Protection "1; mode=block" always;
+  add_header Alt-Svc 'h3=":443"; ma=86400' always;
+
+  # Proxy settings
+  location / {
+    proxy_pass https://10.250.0.2:8006;
+    proxy_http_version 1.1;
+
+    # Proxy headers
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Port $server_port;
+
+    # WebSocket support
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+    # Timeouts
+    proxy_connect_timeout 60s;
+    proxy_send_timeout 60s;
+    proxy_read_timeout 60s;
+
+    # Buffering (disable for SSE/streaming)
+    proxy_buffering off;
+    proxy_request_buffering off;
+
+    # Allow large uploads
+    client_max_body_size 100M;
+  }
+}


### PR DESCRIPTION
This pull request adds a new Nginx reverse proxy configuration for the `fortwayne-proxmox.opensource.mieweb.org` server. The configuration enables secure HTTPS access with modern TLS settings, HTTP/2 and HTTP/3 support, and optimized proxying to a backend Proxmox server. The most important changes are:

**New Reverse Proxy Configuration:**

* Added a new server block in `fortwayne-proxmox.conf` to handle HTTPS, HTTP/2, and HTTP/3 traffic for `fortwayne-proxmox.opensource.mieweb.org`, proxying requests to the internal Proxmox server at `10.250.0.2:8006`.

**Security and Performance Enhancements:**

* Configured SSL with modern protocols (TLSv1.2, TLSv1.3), strong ciphers, OCSP stapling, and security headers such as HSTS, X-Frame-Options, and X-Content-Type-Options.
* Enabled HTTP/2 and HTTP/3 (QUIC) support for improved performance and compatibility.

**Proxy and WebSocket Support:**

* Set up proxy headers for correct forwarding of client information and enabled WebSocket support by handling `Upgrade` and `Connection` headers.
* Increased `client_max_body_size` to 100MB to support large uploads,