### PR TITLE
add landing configuration for Nginx reverse proxy

### DIFF
--- a/nginx-reverse-proxy/conf.d/landing.conf
+++ b/nginx-reverse-proxy/conf.d/landing.conf
@@ -1,0 +1,68 @@
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  listen 443 quic;
+  listen [::]:443 quic;
+  http2 on;
+  http3 on;
+
+  server_name opensource.mieweb.org;
+
+  # SSL certificates
+  ssl_certificate /root/.acme.sh/opensource.mieweb.org/fullchain.cer;
+  ssl_certificate_key /root/.acme.sh/opensource.mieweb.org/opensource.mieweb.org.key;
+
+  # Modern TLS configuration
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
+  ssl_prefer_server_ciphers off;
+
+  # SSL session optimization
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_timeout 10m;
+  ssl_session_tickets off;
+
+  # OCSP stapling
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  ssl_trusted_certificate /root/.acme.sh/opensource.mieweb.org/fullchain.cer;
+  resolver 1.1.1.1 8.8.8.8 valid=300s;
+  resolver_timeout 5s;
+
+  # Security headers
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+  add_header X-Frame-Options "SAMEORIGIN" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-XSS-Protection "1; mode=block" always;
+  add_header Alt-Svc 'h3=":443"; ma=86400' always;
+
+  # Proxy settings
+  location / {
+    proxy_pass http://10.15.0.4:2998;
+    proxy_http_version 1.1;
+
+    # Proxy headers
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Port $server_port;
+
+    # WebSocket support
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+    # Timeouts
+    proxy_connect_timeout 60s;
+    proxy_send_timeout 60s;
+    proxy_read_timeout 60s;
+
+    # Buffering (disable for SSE/streaming)
+    proxy_buffering off;
+    proxy_request_buffering off;
+
+    # Allow large uploads
+    client_max_body_size 100M;
+  }
+}


### PR DESCRIPTION
This pull request introduces a new Nginx server configuration for `opensource.mieweb.org`, enabling secure HTTPS access with modern TLS, HTTP/2, and HTTP/3 support, and proxying requests to a backend service. The configuration also includes enhanced security headers and optimizations for SSL performance.

**New Nginx reverse proxy configuration:**

* Added a new server block in `landing.conf` to listen on port 443 with SSL, HTTP/2, and HTTP/3 (QUIC) enabled for `opensource.mieweb.org`.
* Configured SSL certificates, modern TLS protocols/ciphers, session optimizations, and OCSP stapling for improved security and performance.
* Added security headers such as `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `X-XSS-Protection` to enhance browser security.
* Set up a reverse proxy to forward requests to the backend at `10.15.0.4:2998`, including support for WebSockets, appropriate proxy headers, timeouts, and large file uploads.