### PR TITLE
adjust CONTAINER_ID allocation for Fort Wayne by adding 20000 to the …

### DIFF
--- a/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/create-container-new.sh
+++ b/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/create-container-new.sh
@@ -169,6 +169,7 @@ elif [[ "${AI_CONTAINER^^}" == "FORTWAYNE" ]]; then
     CTID_TEMPLATE="103"
     # allocate nextid directly on Fort Wayne
     CONTAINER_ID=$(ssh root@10.250.0.2 pvesh get /cluster/nextid)
+    CONTAINER_ID=$((CONTAINER_ID + 20000))
 
     echo "DEBUG: Cloning on Fort Wayne (10.250.0.2) CTID_TEMPLATE=${CTID_TEMPLATE} -> CONTAINER_ID=${CONTAINER_ID}"
     ssh root@10.250.0.2 pct clone $CTID_TEMPLATE $CONTAINER_ID \


### PR DESCRIPTION
This pull request makes a targeted update to the container creation script for Fort Wayne. The main change is an adjustment to the way container IDs are generated to avoid potential conflicts.

Container ID allocation update:

* In `create-container-new.sh`, when creating a container on Fort Wayne, the script now adds 20,000 to the next available container ID retrieved from the cluster to ensure IDs are in a separate range and avoid collisions.…next available ID