### PR TITLE
add default SSL configuration for Nginx reverse proxy

### DIFF
--- a/nginx-reverse-proxy/conf.d/default-ssl.conf
+++ b/nginx-reverse-proxy/conf.d/default-ssl.conf
@@ -1,0 +1,41 @@
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  listen 443 quic;
+  listen [::]:443 quic;
+  http2 on;
+  http3 on;
+
+  server_name _;
+
+  # SSL certificates
+  ssl_certificate /root/.acme.sh/opensource.mieweb.org/fullchain.cer;
+  ssl_certificate_key /root/.acme.sh/opensource.mieweb.org/opensource.mieweb.org.key;
+
+  # Modern TLS configuration
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
+  ssl_prefer_server_ciphers off;
+
+  # SSL session optimization
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_timeout 10m;
+  ssl_session_tickets off;
+
+  # OCSP stapling
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  ssl_trusted_certificate /root/.acme.sh/opensource.mieweb.org/fullchain.cer;
+  resolver 1.1.1.1 8.8.8.8 valid=300s;
+  resolver_timeout 5s;
+
+  # Security headers
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+  add_header X-Frame-Options "SAMEORIGIN" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-XSS-Protection "1; mode=block" always;
+  add_header Alt-Svc 'h3=":443"; ma=86400' always;
+
+  # Return 404 for un-handled hostnames
+  return 404;
+}


### PR DESCRIPTION
This pull request adds a new Nginx SSL configuration file to enable secure connections with modern TLS, HTTP/2, and HTTP/3 support, as well as improved security headers and certificate management.

**New SSL server configuration:**

* Introduced `default-ssl.conf` to configure Nginx to listen on port 443 with SSL, HTTP/2, and HTTP/3 (QUIC) enabled.
* Configured SSL certificates and modern TLS protocols/ciphers for strong encryption.
* Enabled SSL session optimization and OCSP stapling for improved performance and certificate validation.
* Added security headers such as HSTS, X-Frame-Options, X-Content-Type-Options, and X-XSS-Protection for better browser security.
* Configured the server to return a 404 error for unhandled hostnames, preventing accidental exposure of the default server.