### PR TITLE
refactor: replace random root password generation with disabling root…

### DIFF
--- a/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/create-container-new.sh
+++ b/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/create-container-new.sh
@@ -239,8 +239,7 @@ if [ -f "/var/lib/vz/snippets/container-public-keys/$PUB_FILE" ]; then
         fi
 fi
 
-ROOT_PSWD=$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20)
-run_pct_exec $CONTAINER_ID bash -c "echo root:$ROOT_PSWD | chpasswd" > /dev/null 2>&1
+run_pct_exec $CONTAINER_ID bash -c 'passwd -d root; passwd -l root' > /dev/null 2>&1
 
 CONTAINER_IP=""
 attempts=0

--- a/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/create-container.sh
+++ b/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/create-container.sh
@@ -136,8 +136,7 @@ if [ -f "/var/lib/vz/snippets/container-public-keys/$PUB_FILE" ]; then
 fi
 
 # Generate a random root password for the container
-ROOT_PSWD=$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20)
-pct exec $CONTAINER_ID -- bash -c "echo root:$ROOT_PSWD | chpasswd" > /dev/null 2>&1
+pct exec $CONTAINER_ID -- bash -c 'passwd -d root; passwd -l root' > /dev/null 2>&1
 
 CONTAINER_IP=""
 attempts=0


### PR DESCRIPTION
… password for containers

This pull request updates the way root account credentials are handled during container creation. Instead of generating and setting a random root password, the scripts now explicitly delete and lock the root password, preventing password-based root login by default. This improves security by ensuring the root account cannot be accessed with a password immediately after container creation.

Security improvements to container creation scripts:

* Updated `create-container.sh` and `create-container-new.sh` to delete and lock the root password for the root account instead of generating and setting a random password. This change prevents password-based root login by default. [[1]](diffhunk://#diff-ea7a218a904466f191ccb28b7559ed0caaac952504ba4fb232725f7c1f09ba13L139-R139) [[2]](diffhunk://#diff-3eb44ba43a77cf674f100bed9c5194b50cac723f8e7fcac5539f3f16f920be50L242-R242)