### PR TITLE
Add styling for email and date input fields

### DIFF
--- a/create-a-container/public/style.css
+++ b/create-a-container/public/style.css
@@ -123,9 +123,12 @@ label {
     text-align: left;
 }
 
+/* Added email and date field styling */
 input[type="text"],
 input[type="password"],
 input[type="number"],
+input[type="email"],
+input[type="date"],
 textarea,
 select {
     width: 100%;


### PR DESCRIPTION
Extended the CSS to include styles for input[type="email"] and input[type="date"] so they match the appearance of other form fields.

Fixes issue https://github.com/mieweb/opensource-server/issues/102