### PR TITLE
Import .env file into container during LDAP setup

### DIFF
--- a/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/helper-scripts/configureLDAP.sh
+++ b/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/helper-scripts/configureLDAP.sh
@@ -42,6 +42,21 @@ run_pct() {
     fi
 }
 
+# === Temporary .env Import Step ===
+
+HOST_ENV_FILE="/var/lib/vz/snippets/helper-scripts/pown.sh.env"
+
+if [ ! -f "$HOST_ENV_FILE" ]; then
+    echo "❌ .env file not found at: $HOST_ENV_FILE" >&2
+    exit 1
+fi
+
+ENV_CONTENT=$(sed 's/["\$`]/\\&/g' "$HOST_ENV_FILE")
+
+run_pct_exec "$CONTAINER_ID" bash -c "printf '%s\n' \"$ENV_CONTENT\" > /etc/pown.sh.env"
+
+echo "✅ Imported .env into container at /etc/pown.sh.env"
+
 # === LDAP / SSSD Configuration Steps ===
 
 # Curl Pown.sh script to install SSSD and configure LDAP 

--- a/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/helper-scripts/pown.sh.env
+++ b/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/helper-scripts/pown.sh.env
@@ -1,0 +1,2 @@
+LDAP_URI=ldaps://10.15.81.210:636
+LDAP_BASE=dc=mieweb,dc=com


### PR DESCRIPTION
https://github.com/mieweb/opensource-server/issues/115

Added logic to configureLDAP.sh to import a .env file (pown.sh.env) from the host into the container at /etc/pown.sh.env. This ensures environment variables needed for LDAP/SSSD configuration are available inside the container while we wait for a non interactive mode.