### PR TITLE
Fort Wayne AI container template CTID change

### DIFF
--- a/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/create-container-new.sh
+++ b/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/create-container-new.sh
@@ -166,7 +166,7 @@ if [[ "${AI_CONTAINER^^}" == "PHOENIX" ]]; then
 
 elif [[ "${AI_CONTAINER^^}" == "FORTWAYNE" ]]; then
     echo "⏳ Fort Wayne AI container requested. Using template CTID 103 on 10.250.0.2..."
-    CTID_TEMPLATE="20113"
+    CTID_TEMPLATE="113"
     # allocate nextid directly on Fort Wayne
     CONTAINER_ID=$(ssh root@10.250.0.2 pvesh get /cluster/nextid)
 


### PR DESCRIPTION
Updated the CTID_TEMPLATE value for the Fort Wayne AI container from '20113' to '113' to use the correct template.
Fixes: https://github.com/mieweb/opensource-server/issues/110

Also in sub relation to the erroneous removal of the previous template. 