### PR TITLE
support query params and json output on GET /contiainers

### DIFF
--- a/create-a-container/server.js
+++ b/create-a-container/server.js
@@ -174,9 +174,14 @@ app.post('/login', async (req, res) => {
 app.get('/containers', requireAuth, async (req, res) => {
   // eager-load related services
   const containers = await Container.findAll({
-    where: { username: req.session.user },
+    where: { username: req.session.user, ...req.query },
     include: [{ association: 'services' }]
   });
+
+  // Return JSON if client prefers application/json over text/html
+  if (req.accepts(['json', 'html']) === 'json') {
+    return res.json(containers);
+  }
 
   // Map containers to view models
   const rows = containers.map(c => {


### PR DESCRIPTION
This pull request improves the `/containers` endpoint by adding support for filtering containers using query parameters and by allowing clients to request a JSON response if preferred. These changes enhance the flexibility and usability of the API.

Improvements to API filtering and response format:

* The `where` clause in the `Container.findAll` query now merges `req.session.user` with any query parameters in `req.query`, allowing clients to filter containers by additional fields.
* The endpoint now checks the client's `Accept` header and returns a JSON response if `application/json` is preferred over `text/html`, improving support for API consumers.