### PR TITLE
Add static DNS reservations to dnsmasq.conf

### DIFF
--- a/dnsmasq-service/dnsmasq.conf
+++ b/dnsmasq-service/dnsmasq.conf
@@ -6,6 +6,18 @@ interface=eth0
 listen-address=127.0.0.1,10.15.0.3
 server=8.8.8.8
 
+# Static Reservations
+address=/dns/10.15.0.3
+address=/dns1/10.15.0.3
+address=/ldap/10.15.81.210
+address=/ldap1/10.15.81.210
+address=/pve1/10.15.0.4
+address=/pve2/10.15.0.5
+address=/pve3/10.15.0.6
+address=/pve4/10.15.0.7
+address=/pve5/10.15.0.8
+address=/pve6/10.15.0.9
+
 # DHCP range
 dhcp-range=set:net15,10.15.0.10,10.15.254.254,255.255.0.0,24h
 dhcp-range=set:net16,10.16.0.10,10.16.254.254,255.255.0.0,24h


### PR DESCRIPTION
Added static address mappings for DNS, LDAP, and PVE hosts to dnsmasq.conf to ensure consistent name resolution for these services. These were items that Doug tagged on during an LDAP troubleshooting meeting.