### PR TITLE
Enable Docker inside unprivileged LXCs

### DIFF
--- a/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/create-container-new.sh
+++ b/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/create-container-new.sh
@@ -159,7 +159,9 @@ if [[ "${AI_CONTAINER^^}" == "PHOENIX" ]]; then
         --tags "$PROXMOX_USERNAME" \
         --tags "$LINUX_DISTRO" \
         --tags "AI" \
-        --onboot 1
+        --onboot 1 \
+        --features fuse=1,keyctl=1,nesting=1 \
+        --hookscript local:snippets/hookscript.sh
 
     run_pct start $CONTAINER_ID
     run_pveum aclmod /vms/$CONTAINER_ID --user "$PROXMOX_USERNAME@pve" --role PVEVMUser
@@ -179,7 +181,9 @@ elif [[ "${AI_CONTAINER^^}" == "FORTWAYNE" ]]; then
         --tags "$PROXMOX_USERNAME" \
         --tags "$LINUX_DISTRO" \
         --tags "AI" \
-        --onboot 1
+        --onboot 1 \
+        --features fuse=1,keyctl=1,nesting=1 \
+        --hookscript local:snippets/hookscript.sh
 
     ssh root@10.250.0.2 pct start $CONTAINER_ID
     ssh root@10.250.0.2 pveum aclmod /vms/$CONTAINER_ID --user "$PROXMOX_USERNAME@pve" --role PVEVMUser
@@ -217,7 +221,9 @@ else
         --tags "$PROXMOX_USERNAME" \
         --tags "$LINUX_DISTRO" \
         --tags "LDAP" \
-        --onboot 1
+        --onboot 1 \
+        --features fuse=1,keyctl=1,nesting=1 \
+        --hookscript local:snippets/hookscript.sh
 
     run_pct start $CONTAINER_ID
     run_pveum aclmod /vms/$CONTAINER_ID --user "$PROXMOX_USERNAME@pve" --role PVEVMUser

--- a/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/create-container.sh
+++ b/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/create-container.sh
@@ -115,7 +115,10 @@ if [ "${GH_ACTION^^}" != "Y" ] || [ "${SELF_HOSTED_RUNNER^^}" == "N" ]; then
 		--tags "$PROXMOX_USERNAME" \
 		--tags "$LINUX_DISTRO" \
 		--tags "LDAP" \
-		--onboot 1 > /dev/null 2>&1
+		--onboot 1 \
+                --features fuse=1,keyctl=1,nesting=1 \
+                --hookscript local:snippets/hookscript.sh \
+                > /dev/null 2>&1
 
 	pct start $CONTAINER_ID > /dev/null 2>&1
 	pveum aclmod /vms/$CONTAINER_ID --user "$PROXMOX_USERNAME@pve" --role VMUser2 > /dev/null 2>&1

--- a/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/hookscript.sh
+++ b/container-creation/intern-phxdc-pve1/var-lib-vz-snippets/hookscript.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# /var/lib/vz/snippets/register_proxy_hook.sh
+
+echo "GUEST HOOK: $*"
+
+# First argument is the vmid
+vmid="$1"
+
+# Second argument is the phase
+phase="$2"
+
+case "$phase" in
+    'pre-start')
+        # shellcheck disable=SC2016
+        echo 'Setting AppArmor profile to `unconfined`'
+        conffile="/etc/pve/lxc/$vmid.conf"
+        if grep -qE '^lxc\.apparmor\.profile' "$conffile"; then
+            sed -i -E 's/^lxc\.apparmor\.profile: .*$/lxc.apparmor.profile: unconfined/' "$conffile"
+        else
+            echo 'lxc.apparmor.profile: unconfined' >>"$conffile"
+        fi
+    ;;
+    'post-start') ;;
+    'pre-stop') ;;
+    'post-stop') ;;
+    *)
+        echo "got unknown phase '$phase'" >&2
+        exit 255
+    ;;
+esac


### PR DESCRIPTION
This pull request enhances the container creation process by adding new container features and introducing a hook script to set the AppArmor profile for LXC containers. The changes ensure that all newly created containers have the required features enabled and are configured for better compatibility and flexibility.

**Container configuration improvements:**

* Added `--features fuse=1,keyctl=1,nesting=1` and `--hookscript local:hookscript.sh` to the container creation commands in `create-container-new.sh` and `create-container.sh`, enabling FUSE, keyctl, nesting, and custom hook script execution for all containers. [[1]](diffhunk://#diff-3eb44ba43a77cf674f100bed9c5194b50cac723f8e7fcac5539f3f16f920be50L162-R164) [[2]](diffhunk://#diff-3eb44ba43a77cf674f100bed9c5194b50cac723f8e7fcac5539f3f16f920be50L182-R186) [[3]](diffhunk://#diff-3eb44ba43a77cf674f100bed9c5194b50cac723f8e7fcac5539f3f16f920be50L220-R226) [[4]](diffhunk://#diff-ea7a218a904466f191ccb28b7559ed0caaac952504ba4fb232725f7c1f09ba13L118-R121)

**Hook script addition:**

* Introduced a new `hookscript.sh` that sets the AppArmor profile to `unconfined` during the container's `pre-start` phase, improving container compatibility with certain workloads.