### PR TITLE
implement proper api returns

### DIFF
--- a/create-a-container/openapi.yaml
+++ b/create-a-container/openapi.yaml
@@ -399,8 +399,22 @@ paths:
       security:
         - BearerAuth: []
       responses:
-        '204':
+        '200':
           description: Container deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  msg:
+                    type: string
+                    example: Container deleted successfully
+                  dnsWarnings:
+                    type: array
+                    items:
+                      type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':

--- a/create-a-container/routers/containers.js
+++ b/create-a-container/routers/containers.js
@@ -637,20 +637,11 @@ router.delete('/:id', requireAuth, async (req, res) => {
   const siteId = parseInt(req.params.siteId, 10);
   const containerId = parseInt(req.params.id, 10);
 
-  if (isApiRequest(req)) {
-    try {
-      const container = await Container.findByPk(containerId);
-      if (!container) return res.status(404).json({ error: 'Not found' });
-      await container.destroy(); // Triggers hooks/cascades
-      return res.status(204).send();
-    } catch (err) {
-      console.error('API DELETE Error:', err);
-      return res.status(500).json({ error: 'Internal server error' });
-    }
-  }
-  
   const site = await Site.findByPk(siteId);
-  if (!site) return res.redirect('/sites');
+  if (!site) {
+    if (isApiRequest(req)) return res.status(404).json({ error: 'Site not found' });
+    return res.redirect('/sites');
+  }
   
   const container = await Container.findOne({
     where: { id: containerId, username: req.session.user },
@@ -661,7 +652,9 @@ router.delete('/:id', requireAuth, async (req, res) => {
   });
   
   if (!container || !container.node || container.node.siteId !== siteId) {
-    await req.flash('error', 'Container not found or access denied');
+    const error = 'Container not found';
+    if (isApiRequest(req)) return res.status(404).json({ error });
+    await req.flash('error', error);
     return res.redirect(`/sites/${siteId}/containers`);
   }
   
@@ -681,7 +674,9 @@ router.delete('/:id', requireAuth, async (req, res) => {
       try {
         const config = await api.lxcConfig(node.name, container.containerId);
         if (config.hostname && config.hostname !== container.hostname) {
-           await req.flash('error', `Hostname mismatch (DB: ${container.hostname} vs Proxmox: ${config.hostname}). Delete aborted.`);
+           const error = `Hostname mismatch (DB: ${container.hostname} vs Proxmox: ${config.hostname}). Delete aborted.`;
+           if (isApiRequest(req)) return res.status(400).json({ error });
+           await req.flash('error', error);
            return res.redirect(`/sites/${siteId}/containers`);
         }
         await api.deleteContainer(node.name, container.containerId, true, true);
@@ -692,11 +687,13 @@ router.delete('/:id', requireAuth, async (req, res) => {
     await container.destroy();
   } catch (error) {
     console.error(error);
+    if (isApiRequest(req)) return res.status(500).json({ error });
     await req.flash('error', `Failed to delete: ${error.message}`);
     return res.redirect(`/sites/${siteId}/containers`);
   }
   
   let msg = 'Container deleted successfully';
+  if (isApiRequest(req)) return res.status(200).json({ msg, dnsWarnings });
   for (const w of dnsWarnings) msg += ` ⚠️ ${w}`;
   await req.flash('success', msg);
   return res.redirect(`/sites/${siteId}/containers`);


### PR DESCRIPTION
This pull request updates the API and backend logic for deleting containers to provide more informative and consistent responses, especially for API clients. The main improvements are the switch from a 204 to a 200 response with a JSON body for successful deletions, better error handling with appropriate status codes and messages, and alignment between the OpenAPI spec and backend implementation.

**API Response Improvements**
* The OpenAPI spec (`openapi.yaml`) now documents a 200 response with a JSON body (including a success message and DNS warnings) for successful container deletions, instead of a 204 with no content. It also adds a 400 response for bad requests.
* The backend route (`routers/containers.js`) now returns a 200 JSON response with a message and DNS warnings on successful API deletes, matching the updated spec.

**Error Handling Enhancements**
* API requests now receive specific JSON error responses and appropriate HTTP status codes (404 for not found, 400 for hostname mismatch, 500 for server errors) instead of generic or missing responses. [[1]](diffhunk://#diff-11460954cbd3d632e6fc21fdd37876dee46ae3a2e4d719ecef5a1b005d2ddb07L640-R644) [[2]](diffhunk://#diff-11460954cbd3d632e6fc21fdd37876dee46ae3a2e4d719ecef5a1b005d2ddb07L664-R657) [[3]](diffhunk://#diff-11460954cbd3d632e6fc21fdd37876dee46ae3a2e4d719ecef5a1b005d2ddb07L684-R679) [[4]](diffhunk://#diff-11460954cbd3d632e6fc21fdd37876dee46ae3a2e4d719ecef5a1b005d2ddb07R690-R696)

**Consistency and Code Clean-up**
* The logic for handling API and non-API requests is unified and made more consistent, including improved error messages and redirects for UI users. [[1]](diffhunk://#diff-11460954cbd3d632e6fc21fdd37876dee46ae3a2e4d719ecef5a1b005d2ddb07L640-R644) [[2]](diffhunk://#diff-11460954cbd3d632e6fc21fdd37876dee46ae3a2e4d719ecef5a1b005d2ddb07L664-R657) [[3]](diffhunk://#diff-11460954cbd3d632e6fc21fdd37876dee46ae3a2e4d719ecef5a1b005d2ddb07L684-R679) [[4]](diffhunk://#diff-11460954cbd3d632e6fc21fdd37876dee46ae3a2e4d719ecef5a1b005d2ddb07R690-R696)