### PR TITLE
Update launchpad to use main from cmyers_issue5

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -141,7 +141,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: mieweb/launchpad@cmyers_issue5
+      - uses: mieweb/launchpad@main
         with:
           api_key: ${{ secrets.API_KEY }}
           api_url: ${{ secrets.API_URL }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Remove preview container
-        uses: mieweb/launchpad@cmyers_issue5
+        uses: mieweb/launchpad@main
         with:
           api_key: ${{ secrets.LAUNCHPAD_API_KEY }}
           api_url: ${{ secrets.LAUNCHPAD_API_URL }}


### PR DESCRIPTION
Related issue: https://github.com/mieweb/launchpad/issues/9
Resolves: https://github.com/mieweb/opensource-server/issues/275


Opensource was not updated to use the merged branch to main.