### PR TITLE
create containers on nodes with least current containers

### DIFF
--- a/create-a-container/routers/containers.js
+++ b/create-a-container/routers/containers.js
@@ -351,7 +351,26 @@ router.post('/', async (req, res) => {
       nodeWhere.nvidiaAvailable = true;
     }
 
-    const node = await Node.findOne({ where: nodeWhere });
+    // Select the node with the fewest existing containers to balance load.
+    // LEFT JOINs containers, groups by node, and orders by count ascending
+    // so the least-loaded node is chosen first.
+    const node = await Node.findOne({
+      where: nodeWhere,
+      include: [{
+        model: Container,
+        as: 'containers',
+        attributes: [],
+        required: false
+      }],
+      attributes: {
+        include: [
+          [Sequelize.fn('COUNT', Sequelize.col('containers.id')), 'containerCount']
+        ]
+      },
+      group: ['Node.id'],
+      order: [[Sequelize.fn('COUNT', Sequelize.col('containers.id')), 'ASC']],
+      subQuery: false
+    });
     if (!node && wantsNvidia) {
       throw new Error('NVIDIA requested but no NVIDIA-capable nodes are available in this site');
     }


### PR DESCRIPTION
You can see the node placement logic at work here. Manager and demo already existed on pve1, so pve2 got filled before pve1 started to be used again.

<img width="308" height="386" alt="image" src="https://github.com/user-attachments/assets/a0ca2500-38d3-49cc-821f-b76a86e2ba84" />

# Copilot Summary

This pull request improves the logic for selecting a node when creating a new container, aiming to better balance the load across available nodes. Instead of picking any available node, the system now chooses the node with the fewest existing containers.

**Load balancing improvements:**

* Updated the node selection query in `containers.js` to join with the `Container` model, group by node, and order by the number of containers, ensuring the least-loaded node is chosen for new containers.