### PR TITLE
feat: add one-click dev login buttons

### DIFF
--- a/create-a-container/public/style.css
+++ b/create-a-container/public/style.css
@@ -220,7 +220,7 @@ select:focus {
 }
 
 .signup-section {
-    margin-top: 1.5rem;
+    margin-top: 0;
 }
 
 /* Sidebar styling */

--- a/create-a-container/routers/login.js
+++ b/create-a-container/routers/login.js
@@ -3,15 +3,66 @@ const router = express.Router();
 const { User, Setting } = require('../models');
 const { isSafeRelativeUrl } = require('../utils');
 
+const isDev = process.env.NODE_ENV !== 'production';
+
 // GET / - Display login form
 router.get('/', (req, res) => {
   res.render('login', {
     successMessages: req.flash('success'),
     errorMessages: req.flash('error'),
     warningMessages: req.flash('warning'),
-    redirect: req.query.redirect || '/'
+    redirect: req.query.redirect || '/',
+    isDev
   });
 });
+
+// POST /dev - One-click dev login (non-production only)
+if (isDev) {
+  router.post('/dev', async (req, res) => {
+    const isAdmin = req.body.role === 'admin';
+    const uid = isAdmin ? 'dev-admin' : 'dev-user';
+
+    let user = await User.findOne({
+      where: { uid },
+      include: [{ association: 'groups' }]
+    });
+
+    if (!user) {
+      user = await User.create({
+        uidNumber: await User.nextUidNumber(),
+        uid,
+        givenName: 'Dev',
+        sn: isAdmin ? 'Admin' : 'User',
+        cn: isAdmin ? 'Dev Admin' : 'Dev User',
+        mail: `${uid}@localhost`,
+        userPassword: 'dev-password-not-used',
+        status: 'active',
+        homeDirectory: `/home/${uid}`,
+      });
+
+      // The User afterCreate hook auto-adds the first user to sysadmins.
+      // Adjust group membership to match the requested role.
+      const { Group } = require('../models');
+      const adminGroup = await Group.findByPk(2000);
+      if (adminGroup) {
+        if (isAdmin) {
+          await user.addGroup(adminGroup);
+        } else {
+          await user.removeGroup(adminGroup);
+        }
+      }
+
+      user = await User.findOne({
+        where: { uid },
+        include: [{ association: 'groups' }]
+      });
+    }
+
+    req.session.user = user.uid;
+    req.session.isAdmin = user.groups?.some(g => g.isAdmin) || false;
+    req.session.save(() => res.redirect('/'));
+  });
+}
 
 // POST / - Handle login submission
 router.post('/', async (req, res) => {

--- a/create-a-container/views/login.ejs
+++ b/create-a-container/views/login.ejs
@@ -47,6 +47,20 @@
             <input type="submit" value="Login" id="loginButton">
         </form>
         
+        <% if (isDev) { %>
+            <hr>
+            <div class="signup-section" style="display: flex; gap: 8px; justify-content: center;">
+                <form method="POST" action="/login/dev" style="flex: 1;">
+                    <input type="hidden" name="role" value="admin">
+                    <input type="submit" value="Login as Admin" style="margin-top: 0;">
+                </form>
+                <form method="POST" action="/login/dev" style="flex: 1;">
+                    <input type="hidden" name="role" value="user">
+                    <input type="submit" value="Login as User" style="margin-top: 0;">
+                </form>
+            </div>
+        <% } %>
+        
         <!-- Loading banner for 2FA waiting -->
         <div id="loadingBanner" class="alert alert-info" style="display: none;">
             <strong>⏳ Waiting for authentication...</strong>


### PR DESCRIPTION
Show 'Login as Admin' and 'Login as User' buttons on the login page when NODE_ENV !== 'production'. Creates dev-admin/dev-user accounts on first use, bypassing password authentication. Buttons use the standard submit styling and the admin group is explicitly managed to prevent the first-user hook from granting unintended access.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3b469670-a2e3-412d-84d4-582401b45372" />

# Copilot Summary

This pull request introduces a development-only one-click login feature to streamline local testing and development. It adds a new `/login/dev` endpoint that allows developers to instantly log in as either an admin or a regular user, and updates the login page to display these options when not in production. There are also minor style adjustments to the signup section.

**Development Experience Improvements:**

* Added a development-only `/login/dev` POST endpoint to `login.js` that creates or finds a test user (admin or regular) and logs them in, including proper group assignment. This is only enabled when `NODE_ENV` is not `'production'`.
* Updated the login view (`login.ejs`) to display "Login as Admin" and "Login as User" buttons for one-click development login when in development mode.

**Styling Adjustments:**

* Changed `.signup-section`'s `margin-top` from `1.5rem` to `0` in `style.css` for improved layout, especially with the new dev login buttons.