### PR TITLE
Fixes

### DIFF
--- a/create-a-container/example.env
+++ b/create-a-container/example.env
@@ -18,3 +18,7 @@ POSTGRES_PORT=
 POSTGRES_USER=
 POSTGRES_PASSWORD=
 POSTGRES_DATABASE=
+
+# path to the morgan access log file. if unset, access logs go to stdout.
+# if set, the file is opened in append mode.
+ACCESS_LOG=

--- a/create-a-container/middlewares/currentSite.js
+++ b/create-a-container/middlewares/currentSite.js
@@ -1,4 +1,4 @@
-const { Site } = require('../models');
+const { Site, Setting } = require('../models');
 
 // Middleware to set req.session.currentSite based on the :siteId parameter
 function setCurrentSite(req, res, next) {
@@ -9,7 +9,9 @@ function setCurrentSite(req, res, next) {
   next();
 }
 
-// Middleware to load all sites and attach to res.locals for use in views
+// Middleware to load all sites and attach to res.locals for use in views.
+// Also exposes a small set of layout-wide settings (e.g. push notification URL,
+// used by the sidebar to render the MFA Admin link).
 async function loadSites(req, res, next) {
   try {
     const sites = await Site.findAll({
@@ -23,6 +25,15 @@ async function loadSites(req, res, next) {
     res.locals.sites = [];
     res.locals.currentSite = null;
   }
+
+  try {
+    const pushNotificationUrl = await Setting.get('push_notification_url');
+    res.locals.pushNotificationUrl = pushNotificationUrl?.trim() || '';
+  } catch (error) {
+    console.error('Error loading push notification URL:', error);
+    res.locals.pushNotificationUrl = '';
+  }
+
   next();
 }
 

--- a/create-a-container/public/style.css
+++ b/create-a-container/public/style.css
@@ -258,8 +258,10 @@ select:focus {
   margin-right: 0.5rem;
 }
 
-/* Mobile: Make sidebar full-width when expanded */
-@media (max-width: 767.98px) {
+/* Mobile/tablet: Make sidebar full-width when expanded.
+   Matches the navbar's navbar-expand-lg breakpoint so the sidebar
+   collapses whenever the navbar toggler is visible. */
+@media (max-width: 991.98px) {
   .sidebar {
     position: fixed;
     top: 56px;

--- a/create-a-container/routers/containers.js
+++ b/create-a-container/routers/containers.js
@@ -8,6 +8,7 @@ const serviceMap = require('../data/services.json');
 const { isApiRequest } = require('../utils/http');
 const { parseDockerRef, getImageConfig, extractImageMetadata } = require('../utils/docker-registry');
 const { manageDnsRecords } = require('../utils/cloudflare-dns');
+const { formatSequelizeError } = require('../utils');
 
 /**
  * Normalize a Docker image reference to full format: host/org/image:tag
@@ -663,7 +664,7 @@ router.put('/:id', requireAuth, async (req, res) => {
     return res.redirect(`/sites/${siteId}/containers`);
   } catch (err) {
     console.error('Error updating container:', err);
-    await req.flash('error', 'Failed to update container: ' + err.message);
+    await req.flash('error', 'Failed to update container: ' + formatSequelizeError(err));
     return res.redirect(`/sites/${siteId}/containers/${containerId}/edit`);
   }
 });
@@ -724,7 +725,7 @@ router.delete('/:id', requireAuth, async (req, res) => {
   } catch (error) {
     console.error(error);
     if (isApiRequest(req)) return res.status(500).json({ error });
-    await req.flash('error', `Failed to delete: ${error.message}`);
+    await req.flash('error', `Failed to delete: ${formatSequelizeError(error)}`);
     return res.redirect(`/sites/${siteId}/containers`);
   }
   

--- a/create-a-container/routers/external-domains.js
+++ b/create-a-container/routers/external-domains.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { ExternalDomain, Site } = require('../models');
 const { requireAuth, requireAdmin } = require('../middlewares');
+const { formatSequelizeError } = require('../utils');
 
 // All routes require authentication + admin
 router.use(requireAuth);
@@ -76,7 +77,7 @@ router.post('/', async (req, res) => {
     return res.redirect('/external-domains');
   } catch (error) {
     console.error('Error creating external domain:', error);
-    await req.flash('error', 'Failed to create external domain: ' + error.message);
+    await req.flash('error', 'Failed to create external domain: ' + formatSequelizeError(error));
     return res.redirect('/external-domains/new');
   }
 });
@@ -115,7 +116,7 @@ router.put('/:id', async (req, res) => {
     return res.redirect('/external-domains');
   } catch (error) {
     console.error('Error updating external domain:', error);
-    await req.flash('error', 'Failed to update external domain: ' + error.message);
+    await req.flash('error', 'Failed to update external domain: ' + formatSequelizeError(error));
     return res.redirect(`/external-domains/${domainId}/edit`);
   }
 });
@@ -139,7 +140,7 @@ router.delete('/:id', async (req, res) => {
     return res.redirect('/external-domains');
   } catch (error) {
     console.error('Error deleting external domain:', error);
-    await req.flash('error', 'Failed to delete external domain: ' + error.message);
+    await req.flash('error', 'Failed to delete external domain: ' + formatSequelizeError(error));
     return res.redirect('/external-domains');
   }
 });

--- a/create-a-container/routers/groups.js
+++ b/create-a-container/routers/groups.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { Group, User } = require('../models');
 const { requireAuth, requireAdmin } = require('../middlewares');
+const { formatSequelizeError } = require('../utils');
 
 // Apply auth and admin check to all routes
 router.use(requireAuth);
@@ -72,7 +73,7 @@ router.post('/', async (req, res) => {
     return res.redirect('/groups');
   } catch (error) {
     console.error('Error creating group:', error);
-    await req.flash('error', 'Failed to create group: ' + error.message);
+    await req.flash('error', 'Failed to create group: ' + formatSequelizeError(error));
     return res.redirect('/groups/new');
   }
 });
@@ -98,7 +99,7 @@ router.put('/:id', async (req, res) => {
     return res.redirect('/groups');
   } catch (error) {
     console.error('Error updating group:', error);
-    await req.flash('error', 'Failed to update group: ' + error.message);
+    await req.flash('error', 'Failed to update group: ' + formatSequelizeError(error));
     return res.redirect(`/groups/${req.params.id}/edit`);
   }
 });
@@ -120,7 +121,7 @@ router.delete('/:id', async (req, res) => {
     return res.redirect('/groups');
   } catch (error) {
     console.error('Error deleting group:', error);
-    await req.flash('error', 'Failed to delete group: ' + error.message);
+    await req.flash('error', 'Failed to delete group: ' + formatSequelizeError(error));
     return res.redirect('/groups');
   }
 });

--- a/create-a-container/routers/nodes.js
+++ b/create-a-container/routers/nodes.js
@@ -5,6 +5,7 @@ const { requireAuth, requireAdmin } = require('../middlewares');
 const axios = require('axios');
 const https = require('https');
 const ProxmoxApi = require('../utils/proxmox-api');
+const { formatSequelizeError } = require('../utils');
 
 // Apply auth and admin check to all routes
 router.use(requireAuth);
@@ -137,7 +138,7 @@ router.post('/', async (req, res) => {
     return res.redirect(`/sites/${siteId}/nodes`);
   } catch (err) {
     console.error('Error creating node:', err);
-    await req.flash('error', `Failed to create node: ${err.message}`);
+    await req.flash('error', `Failed to create node: ${formatSequelizeError(err)}`);
     return res.redirect(`/sites/${siteId}/nodes/new`);
   }
 });
@@ -259,7 +260,7 @@ router.post('/import', async (req, res) => {
     res.redirect(`/sites/${siteId}/nodes`);
   } catch (err) {
     console.log(err);
-    await req.flash('error', `Failed to import nodes: ${err.message}`);
+    await req.flash('error', `Failed to import nodes: ${formatSequelizeError(err)}`);
     return res.redirect(`/sites/${siteId}/nodes/import`);
   }
 });
@@ -310,7 +311,7 @@ router.put('/:id', async (req, res) => {
     return res.redirect(`/sites/${siteId}/nodes`);
   } catch (err) {
     console.error('Error updating node:', err);
-    await req.flash('error', `Failed to update node: ${err.message}`);
+    await req.flash('error', `Failed to update node: ${formatSequelizeError(err)}`);
     return res.redirect(`/sites/${siteId}/nodes/${nodeId}/edit`);
   }
 });
@@ -377,7 +378,7 @@ router.delete('/:id', async (req, res) => {
     return res.redirect(`/sites/${siteId}/nodes`);
   } catch (err) {
     console.error('Error deleting node:', err);
-    await req.flash('error', `Failed to delete node: ${err.message}`);
+    await req.flash('error', `Failed to delete node: ${formatSequelizeError(err)}`);
     return res.redirect(`/sites/${siteId}/nodes`);
   }
 });

--- a/create-a-container/routers/register.js
+++ b/create-a-container/routers/register.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const QRCode = require('qrcode');
 const { User, InviteToken, Setting } = require('../models');
 const { sendPushNotificationInvite } = require('../utils/push-notification-invite');
+const { formatSequelizeError } = require('../utils');
 
 // GET / - Display registration form
 router.get('/', async (req, res) => {
@@ -150,7 +151,7 @@ router.post('/', async (req, res) => {
         await req.flash('error', 'A user with these details is already registered. Please login with your existing account.');
       }
     } else {
-      await req.flash('error', 'Registration failed: ' + err.message);
+      await req.flash('error', 'Registration failed: ' + formatSequelizeError(err));
     }
     
     // Preserve invite token in redirect if present

--- a/create-a-container/routers/sites.js
+++ b/create-a-container/routers/sites.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { Site, Node, Container, Service, HTTPService, TransportService, ExternalDomain } = require('../models');
 const { requireAuth, requireAdmin, requireLocalhostOrAdmin, setCurrentSite, isApiRequest } = require('../middlewares');
+const { formatSequelizeError } = require('../utils');
 
 const router = express.Router();
 
@@ -185,7 +186,7 @@ router.post('/', requireAdmin, async (req, res) => {
     return res.redirect('/sites');
   } catch (error) {
     console.error('Error creating site:', error);
-    await req.flash('error', 'Failed to create site: ' + error.message);
+    await req.flash('error', 'Failed to create site: ' + formatSequelizeError(error));
     return res.redirect('/sites/new');
   }
 });
@@ -216,7 +217,7 @@ router.put('/:id', requireAdmin, async (req, res) => {
     return res.redirect('/sites');
   } catch (error) {
     console.error('Error updating site:', error);
-    await req.flash('error', 'Failed to update site: ' + error.message);
+    await req.flash('error', 'Failed to update site: ' + formatSequelizeError(error));
     return res.redirect(`/sites/${req.params.id}/edit`);
   }
 });
@@ -245,7 +246,7 @@ router.delete('/:id', requireAdmin, async (req, res) => {
     return res.redirect('/sites');
   } catch (error) {
     console.error('Error deleting site:', error);
-    await req.flash('error', 'Failed to delete site: ' + error.message);
+    await req.flash('error', 'Failed to delete site: ' + formatSequelizeError(error));
     return res.redirect('/sites');
   }
 });

--- a/create-a-container/routers/users.js
+++ b/create-a-container/routers/users.js
@@ -4,6 +4,7 @@ const { User, Group, InviteToken, Setting } = require('../models');
 const { requireAuth, requireAdmin } = require('../middlewares');
 const { sendInviteEmail } = require('../utils/email');
 const { sendPushNotificationInvite } = require('../utils/push-notification-invite');
+const { formatSequelizeError } = require('../utils');
 
 // Apply auth and admin check to all routes
 router.use(requireAuth);
@@ -100,7 +101,7 @@ router.post('/invite', async (req, res) => {
     }
   } catch (error) {
     console.error('Invite error:', error);
-    await req.flash('error', 'Failed to send invitation: ' + error.message);
+    await req.flash('error', 'Failed to send invitation: ' + formatSequelizeError(error));
     return res.redirect('/users/invite');
   }
 });
@@ -165,7 +166,7 @@ router.post('/', async (req, res) => {
     return res.redirect('/users');
   } catch (error) {
     console.error('Error creating user:', error);
-    await req.flash('error', 'Failed to create user: ' + error.message);
+    await req.flash('error', 'Failed to create user: ' + formatSequelizeError(error));
     return res.redirect('/users/new');
   }
 });
@@ -230,7 +231,7 @@ router.put('/:id', async (req, res) => {
     return res.redirect('/users');
   } catch (error) {
     console.error('Error updating user:', error);
-    await req.flash('error', 'Failed to update user: ' + error.message);
+    await req.flash('error', 'Failed to update user: ' + formatSequelizeError(error));
     return res.redirect(`/users/${uidNumber}/edit`);
   }
 });
@@ -254,7 +255,7 @@ router.delete('/:id', async (req, res) => {
     return res.redirect('/users');
   } catch (error) {
     console.error('Error deleting user:', error);
-    await req.flash('error', 'Failed to delete user: ' + error.message);
+    await req.flash('error', 'Failed to delete user: ' + formatSequelizeError(error));
     return res.redirect('/users');
   }
 });

--- a/create-a-container/server.js
+++ b/create-a-container/server.js
@@ -3,6 +3,7 @@ require('dotenv').config();
 const express = require('express');
 const session = require('express-session');
 const morgan = require('morgan');
+const fs = require('fs');
 const SequelizeStore = require('express-session-sequelize')(session.Store);
 const flash = require('connect-flash');
 const methodOverride = require('method-override');
@@ -43,7 +44,10 @@ async function main() {
   app.set('trust proxy', 1);
 
   // setup middleware
-  app.use(morgan('combined'));
+  const accessLogStream = process.env.ACCESS_LOG
+    ? fs.createWriteStream(process.env.ACCESS_LOG, { flags: 'a' })
+    : process.stdout;
+  app.use(morgan('combined', { stream: accessLogStream }));
   app.use(express.json());
   app.use(express.urlencoded({ extended: true })); // Parse form data
   app.use(methodOverride((req, res) => {

--- a/create-a-container/systemd/container-creator-init.service
+++ b/create-a-container/systemd/container-creator-init.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Initialize PostgreSQL for Container Creator
 After=postgresql.service
-ConditionPathExists=!/opt/opensource-server/create-a-container/.env
+ConditionPathExists=!/etc/default/container-creator
 
 [Service]
 Type=oneshot
@@ -9,17 +9,18 @@ RemainAfterExit=yes
 WorkingDirectory=/opt/opensource-server/create-a-container
 ExecStart=/bin/bash -e -c '\
   for i in {1..30}; do pg_isready -h localhost && break || sleep 1; done; \
-  POSTGRES_PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24); \
-  POSTGRES_USER="cluster_manager"; \
-  POSTGRES_DATABASE="cluster_manager"; \
-  POSTGRES_HOST="localhost"; \
+  export DATABASE_DIALECT=postgres; \
+  export POSTGRES_PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24); \
+  export POSTGRES_USER="cluster_manager"; \
+  export POSTGRES_DATABASE="cluster_manager"; \
+  export POSTGRES_HOST="localhost"; \
   sudo -u postgres psql -c "CREATE USER $${POSTGRES_USER} WITH PASSWORD '"'"'$${POSTGRES_PASSWORD}'"'"';"; \
   sudo -u postgres psql -c "CREATE DATABASE $${POSTGRES_DATABASE} OWNER $${POSTGRES_USER};"; \
-  echo "DATABASE_DIALECT=postgres" > .env; \
-  echo "POSTGRES_HOST=$${POSTGRES_HOST}" >> .env; \
-  echo "POSTGRES_DATABASE=$${POSTGRES_DATABASE}" >> .env; \
-  echo "POSTGRES_USER=$${POSTGRES_USER}" >> .env; \
-  echo "POSTGRES_PASSWORD=$${POSTGRES_PASSWORD}" >> .env; \
+  echo "DATABASE_DIALECT=$${DATABASE_DIALECT}" > /etc/default/container-creator; \
+  echo "POSTGRES_HOST=$${POSTGRES_HOST}" >> /etc/default/container-creator; \
+  echo "POSTGRES_DATABASE=$${POSTGRES_DATABASE}" >> /etc/default/container-creator; \
+  echo "POSTGRES_USER=$${POSTGRES_USER}" >> /etc/default/container-creator; \
+  echo "POSTGRES_PASSWORD=$${POSTGRES_PASSWORD}" >> /etc/default/container-creator; \
   npm run db:migrate;'
 
 [Install]

--- a/create-a-container/systemd/container-creator.service
+++ b/create-a-container/systemd/container-creator.service
@@ -10,6 +10,7 @@ WorkingDirectory=/opt/opensource-server/create-a-container
 ExecStart=/usr/bin/node /opt/opensource-server/create-a-container/server.js
 Restart=on-failure
 Environment=NODE_ENV=production
+Environment=ACCESS_LOG=/var/log/opensource-server/access.log
 
 [Install]
 WantedBy=multi-user.target

--- a/create-a-container/systemd/container-creator.service
+++ b/create-a-container/systemd/container-creator.service
@@ -11,6 +11,7 @@ ExecStart=/usr/bin/node /opt/opensource-server/create-a-container/server.js
 Restart=on-failure
 Environment=NODE_ENV=production
 Environment=ACCESS_LOG=/var/log/opensource-server/access.log
+EnvironmentFile=/etc/default/container-creator
 
 [Install]
 WantedBy=multi-user.target

--- a/create-a-container/utils/index.js
+++ b/create-a-container/utils/index.js
@@ -97,10 +97,26 @@ function isSafeRedirectUrl(url, allowedDomains = []) {
   }
 }
 
+/**
+ * Convert a Sequelize validation or constraint error into a plain-english
+ * message by joining the per-item messages from `err.errors`. Falls back to
+ * the error's own `message` for non-Sequelize errors.
+ * @param {Error} err
+ * @returns {string}
+ */
+function formatSequelizeError(err) {
+  if (!err) return 'Unknown error';
+  if (Array.isArray(err.errors) && err.errors.length > 0) {
+    return err.errors.map(e => e.message).filter(Boolean).join(' ');
+  }
+  return err.message || 'Unknown error';
+}
+
 module.exports = {
   ProxmoxApi,
   run,
   isSafeRelativeUrl,
   isSafeRedirectUrl,
-  getVersionInfo
+  getVersionInfo,
+  formatSequelizeError
 };

--- a/create-a-container/views/layouts/header.ejs
+++ b/create-a-container/views/layouts/header.ejs
@@ -38,7 +38,7 @@
   <div class="container-fluid" style="margin-top: 56px;">
     <div class="row">
       <!-- Collapsible Sidebar -->
-      <nav id="sidebarMenu" class="col-auto d-md-block bg-dark sidebar collapse">
+      <nav id="sidebarMenu" class="col-auto d-lg-block bg-dark sidebar collapse">
         <div class="position-sticky pt-3">
           <ul class="nav flex-column">
             <% 

--- a/create-a-container/views/layouts/header.ejs
+++ b/create-a-container/views/layouts/header.ejs
@@ -102,6 +102,13 @@
                   Settings
                 </a>
               </li>
+              <% if (typeof pushNotificationUrl !== 'undefined' && pushNotificationUrl) { %>
+                <li class="nav-item">
+                  <a class="nav-link" href="<%= pushNotificationUrl %>/admin" target="_blank" rel="noopener noreferrer">
+                    MFA Admin <i class="bi bi-box-arrow-up-right"></i>
+                  </a>
+                </li>
+              <% } %>
             <% } %>
           </ul>
         </div>

--- a/images/manager/Dockerfile
+++ b/images/manager/Dockerfile
@@ -21,6 +21,12 @@ RUN apt update && apt -y install postgresql-common \
 # override prevents a race condition at boot.
 COPY images/manager/wait-proxmox-regenerate-snakeoil.conf /etc/systemd/system/postgresql@.service.d/
 
+# Directory for the create-a-container access log written by morgan
+# (see Environment=ACCESS_LOG in container-creator.service) and its
+# logrotate config.
+RUN mkdir -p /var/log/opensource-server
+COPY images/manager/opensource-server.logrotate /etc/logrotate.d/opensource-server
+
 # Install the software. We include the .git directory so that the software can
 # update itself without replacing the entire container.
 COPY . /opt/opensource-server

--- a/images/manager/opensource-server.logrotate
+++ b/images/manager/opensource-server.logrotate
@@ -1,0 +1,9 @@
+/var/log/opensource-server/*.log {
+    daily
+    rotate 14
+    missingok
+    notifempty
+    compress
+    delaycompress
+    copytruncate
+}

--- a/mie-opensource-landing/docs/admins/settings.md
+++ b/mie-opensource-landing/docs/admins/settings.md
@@ -27,6 +27,8 @@ Two-factor authentication via push notifications using the [MieWeb Auth App](htt
 2. Check **Enable Push Notification 2FA**
 3. Save
 
+Once a Push Notification URL is configured, an **MFA Admin** link appears at the bottom of the admin sidebar. It opens `${push_notification_url}/admin` in a new tab so admins can manage registered devices in the notification service.
+
 ### Flow
 
 1. User enters username/password


### PR DESCRIPTION
# Migration

1. Install the new container-creator*.service files
2. Copy /opt/opensource-server/create-a-container/.env to /etc/default/container-creator
3. systemctl daemon-reload
4. systemctl restart container-creator

# Copilot Summary

This pull request introduces two main improvements: enhanced error handling across all major routes by standardizing error messages with a utility function, and some minor UI/UX and configuration enhancements. The error handling changes will make it easier to debug issues and provide more consistent feedback to users. Additionally, there are updates to the sidebar's responsive behavior and a new configuration option for access log output.

**Error handling improvements:**

* All routers (`containers.js`, `external-domains.js`, `groups.js`, `nodes.js`, `register.js`, `sites.js`, `users.js`) now use a new `formatSequelizeError` utility to standardize error messages displayed to users after failed database operations. This affects create, update, and delete actions, as well as user registration and invitations. [[1]](diffhunk://#diff-11460954cbd3d632e6fc21fdd37876dee46ae3a2e4d719ecef5a1b005d2ddb07R11) [[2]](diffhunk://#diff-11460954cbd3d632e6fc21fdd37876dee46ae3a2e4d719ecef5a1b005d2ddb07L666-R667) [[3]](diffhunk://#diff-11460954cbd3d632e6fc21fdd37876dee46ae3a2e4d719ecef5a1b005d2ddb07L727-R728) [[4]](diffhunk://#diff-6b08a25643ef349748b6467570e4090c7545b4d70afefbabe19aab9281e7797dR5) [[5]](diffhunk://#diff-6b08a25643ef349748b6467570e4090c7545b4d70afefbabe19aab9281e7797dL79-R80) [[6]](diffhunk://#diff-6b08a25643ef349748b6467570e4090c7545b4d70afefbabe19aab9281e7797dL118-R119) [[7]](diffhunk://#diff-6b08a25643ef349748b6467570e4090c7545b4d70afefbabe19aab9281e7797dL142-R143) [[8]](diffhunk://#diff-be91588bfd1a3ae92cafe990f9df196c7e8b210450df837fffc4c638783207b9R5) [[9]](diffhunk://#diff-be91588bfd1a3ae92cafe990f9df196c7e8b210450df837fffc4c638783207b9L75-R76) [[10]](diffhunk://#diff-be91588bfd1a3ae92cafe990f9df196c7e8b210450df837fffc4c638783207b9L101-R102) [[11]](diffhunk://#diff-be91588bfd1a3ae92cafe990f9df196c7e8b210450df837fffc4c638783207b9L123-R124) [[12]](diffhunk://#diff-c9bae49678bfd6c411208cd9d55a5c42899bd2bc340842695f4fc6652e04102aR8) [[13]](diffhunk://#diff-c9bae49678bfd6c411208cd9d55a5c42899bd2bc340842695f4fc6652e04102aL140-R141) [[14]](diffhunk://#diff-c9bae49678bfd6c411208cd9d55a5c42899bd2bc340842695f4fc6652e04102aL262-R263) [[15]](diffhunk://#diff-c9bae49678bfd6c411208cd9d55a5c42899bd2bc340842695f4fc6652e04102aL313-R314) [[16]](diffhunk://#diff-c9bae49678bfd6c411208cd9d55a5c42899bd2bc340842695f4fc6652e04102aL380-R381) [[17]](diffhunk://#diff-2d7cb4050e1876c998e20e2e25bd9ef19eef416a8568c530e1663b8503a4fd34R6) [[18]](diffhunk://#diff-2d7cb4050e1876c998e20e2e25bd9ef19eef416a8568c530e1663b8503a4fd34L153-R154) [[19]](diffhunk://#diff-9568d251835891d35452e89dea8e6349a20e4d50039cef73d32c74c8b69f6765R4) [[20]](diffhunk://#diff-9568d251835891d35452e89dea8e6349a20e4d50039cef73d32c74c8b69f6765L188-R189) [[21]](diffhunk://#diff-9568d251835891d35452e89dea8e6349a20e4d50039cef73d32c74c8b69f6765L219-R220) [[22]](diffhunk://#diff-9568d251835891d35452e89dea8e6349a20e4d50039cef73d32c74c8b69f6765L248-R249) [[23]](diffhunk://#diff-97d6fec26fc15e32f8e850de934ecf3a435a131ff37b52f3dada1b3b34802775R7) [[24]](diffhunk://#diff-97d6fec26fc15e32f8e850de934ecf3a435a131ff37b52f3dada1b3b34802775L103-R104) [[25]](diffhunk://#diff-97d6fec26fc15e32f8e850de934ecf3a435a131ff37b52f3dada1b3b34802775L168-R169) [[26]](diffhunk://#diff-97d6fec26fc15e32f8e850de934ecf3a435a131ff37b52f3dada1b3b34802775L233-R234) [[27]](diffhunk://#diff-97d6fec26fc15e32f8e850de934ecf3a435a131ff37b52f3dada1b3b34802775L257-R258)

**UI/UX and configuration enhancements:**

* The sidebar's responsive breakpoint was updated to match the navbar's, ensuring the sidebar collapses more consistently with the navigation toggler.
* The `loadSites` middleware now loads and exposes a push notification URL setting to all views, making it easier to display links like "MFA Admin" in the sidebar. [[1]](diffhunk://#diff-87b004960f1c05c59abf7eb2db4c69e07808ac3f51b7d80c33a9b38248d419ffL1-R1) [[2]](diffhunk://#diff-87b004960f1c05c59abf7eb2db4c69e07808ac3f51b7d80c33a9b38248d419ffL12-R14) [[3]](diffhunk://#diff-87b004960f1c05c59abf7eb2db4c69e07808ac3f51b7d80c33a9b38248d419ffR28-R36)
* Added a new `ACCESS_LOG` environment variable in `example.env` and updated the server to optionally write access logs to a file instead of stdout. [[1]](diffhunk://#diff-dec350b7ce4c91e09b6f09936465a2bae3c3d15b54ff87cd4ac9d9051486e868R21-R24) [[2]](diffhunk://#diff-92bfc267052fbd3af60b6bfc31ea9cb187900fd328a920036c1f31cec8c4f6c8R6) [[3]](diffhunk://#diff-92bfc267052fbd3af60b6bfc31ea9cb187900fd328a920036c1f31cec8c4f6c8L46-R50)