### PR TITLE
docs(dev): add local PostgreSQL setup examples

### DIFF
--- a/mie-opensource-landing/docs/developers/development-workflow.md
+++ b/mie-opensource-landing/docs/developers/development-workflow.md
@@ -13,11 +13,61 @@
 ```bash
 git clone https://github.com/mieweb/opensource-server
 cd opensource-server/create-a-container
-cp example.env .env   # Edit with your Proxmox/DB settings
-docker compose up -d   # Start PostgreSQL
+cp example.env .env
+# Edit .env with your Proxmox/DB settings
+```
+
+#### Example local PostgreSQL configuration
+
+After copying `example.env` to `.env`, set the PostgreSQL variables for local development. The values below are examples for a local Docker setup:
+
+```env
+DATABASE_DIALECT=postgres
+
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DATABASE=opensource_server
+```
+
+When using PostgreSQL, the SQLite and MySQL/MariaDB variables can remain blank.
+
+Then start PostgreSQL and run the application:
+
+```bash
+docker compose up -d # Start PostgreSQL
 npm install
 npm run db:migrate
 npm run dev
+```
+
+#### Troubleshooting
+
+On Windows, if Docker Compose fails with an error similar to:
+
+```text
+POSTGRES_PASSWORD is missing a value
+```
+
+make sure `POSTGRES_PASSWORD` is set in `.env`.
+
+If Docker Compose fails with an error similar to:
+
+```text
+open //./pipe/dockerDesktopLinuxEngine: The system cannot find the file specified
+```
+
+make sure Docker Desktop is running, then verify Docker is available:
+
+```bash
+docker ps
+```
+
+After Docker Desktop is running, retry:
+
+```bash
+docker compose up -d
 ```
 
 ### Without Docker


### PR DESCRIPTION
## Summary

This PR clarifies the local Docker Compose setup for new contributors by adding example PostgreSQL `.env` values and common troubleshooting notes.

## Why

While setting up the project locally, Docker Compose can fail if required PostgreSQL environment variables, such as `POSTGRES_PASSWORD`, are left blank after copying `example.env` to `.env`.

This update makes the local development setup easier to follow, especially for contributors setting up the project for the first time.

## Changes

- Added example local PostgreSQL `.env` values for Docker-based development
- Clarified that SQLite and MySQL/MariaDB variables can remain blank when using PostgreSQL
- Added troubleshooting notes for missing `POSTGRES_PASSWORD`
- Added Windows Docker Desktop troubleshooting for the `dockerDesktopLinuxEngine` error

## Testing

- Copied `example.env` to `.env`
- Added local PostgreSQL values
- Ran `docker compose up -d`
- Verified Docker Desktop was running before retrying Docker Compose
- Previewed the Markdown documentation locally