### PR TITLE
Fix manager CT startup in local Docker setup

### DIFF
--- a/images/proxmox-ve/create-manager.sh
+++ b/images/proxmox-ve/create-manager.sh
@@ -5,6 +5,16 @@ CTID="${CTID:-100}"
 BRIDGE="${BRIDGE:-vmbr0}"
 MANAGER_TAG="${MANAGER_TAG:-latest}"
 
+# Leave the Manager CT unpinned by default. In nested Docker/WSL2,
+# forcing a cores value can cause LXC to generate an invalid empty
+# lxc.cgroup.cpuset.cpus line. Set MANAGER_CORES=4 to opt in.
+MANAGER_CORES="${MANAGER_CORES:-}"
+MANAGER_CORE_ARGS=()
+
+if [ -n "$MANAGER_CORES" ]; then
+    MANAGER_CORE_ARGS+=(--cores="${MANAGER_CORES}")
+fi
+
 # Wait for pve-cluster.service to mount the Proxmox cluster filesystem
 until [ -d /etc/pve/local ]; do
     sleep 0.5
@@ -32,7 +42,7 @@ fi
 # `container-creator-init.service` attempting to bootstrap the database before
 # we're ready for it.
 pct create 100 "local:vztmpl/manager_${MANAGER_TAG}.tar" \
-    --cores=4 \
+    "${MANAGER_CORE_ARGS[@]}" \
     --features=nesting=1 \
     --hostname=manager \
     --memory=8192 \
@@ -69,8 +79,11 @@ pct push 100 \
 # sorts of AppArmor and userns problems due to the nested Proxmox-in-Docker.
 pct shutdown 100
 pct set 100 \
-    --mp0=/opt/opensource-server,mp=/opt/opensource-server \
-    --entrypoint=/sbin/init
+    --mp0=/opt/opensource-server,mp=/opt/opensource-server
+
+# Remove the temporary emergency entrypoint before the final start so the
+# Manager CT boots to the default target with networking and services enabled.
+pct set 100 --delete entrypoint || true
 
 # Finally we start the container back up completing this service run.
 pct start 100

--- a/images/proxmox-ve/create-manager.sh
+++ b/images/proxmox-ve/create-manager.sh
@@ -5,15 +5,6 @@ CTID="${CTID:-100}"
 BRIDGE="${BRIDGE:-vmbr0}"
 MANAGER_TAG="${MANAGER_TAG:-latest}"
 
-# Leave the Manager CT unpinned by default. In nested Docker/WSL2,
-# forcing a cores value can cause LXC to generate an invalid empty
-# lxc.cgroup.cpuset.cpus line. Set MANAGER_CORES=4 to opt in.
-MANAGER_CORES="${MANAGER_CORES:-}"
-MANAGER_CORE_ARGS=()
-
-if [ -n "$MANAGER_CORES" ]; then
-    MANAGER_CORE_ARGS+=(--cores="${MANAGER_CORES}")
-fi
 
 # Wait for pve-cluster.service to mount the Proxmox cluster filesystem
 until [ -d /etc/pve/local ]; do
@@ -42,7 +33,6 @@ fi
 # `container-creator-init.service` attempting to bootstrap the database before
 # we're ready for it.
 pct create 100 "local:vztmpl/manager_${MANAGER_TAG}.tar" \
-    "${MANAGER_CORE_ARGS[@]}" \
     --features=nesting=1 \
     --hostname=manager \
     --memory=8192 \
@@ -83,7 +73,7 @@ pct set 100 \
 
 # Remove the temporary emergency entrypoint before the final start so the
 # Manager CT boots to the default target with networking and services enabled.
-pct set 100 --delete entrypoint || true
+pct set 100 --delete entrypoint
 
 # Finally we start the container back up completing this service run.
 pct start 100


### PR DESCRIPTION
## Summary

This PR fixes a local startup issue where the `proxmox` service can become unhealthy because Manager CT `100` does not boot correctly in Docker Desktop + WSL2 environments.

During debugging, Manager CT `100` was created with `cores: 4`, which caused LXC to generate an invalid empty cpuset line:

```text
lxc.cgroup.cpuset.cpus =
```

That prevented CT `100` from starting. After removing the `cores` setting, CT `100` could start, but it still had a temporary emergency boot entrypoint configured:

```text
entrypoint: /sbin/init systemd.unit=emergency.target
```

This PR makes the core limit optional and removes the temporary emergency entrypoint before the final Manager CT startup.

## Changes

* Makes the Manager CT core limit optional using `MANAGER_CORES`.
* Removes the hardcoded `--cores=4` from the default local setup.
* Removes the temporary emergency entrypoint before the final CT startup so Manager boots normally with networking and services enabled.

## Testing

Tested locally on Windows + Ubuntu WSL2 + Docker Desktop.

Started from a clean Docker state:

```bash
docker compose down -v
docker compose build proxmox pull-image
docker compose up -d
```

Verified the Proxmox healthcheck became healthy:

```bash
docker inspect opensource-server-proxmox-1 --format '{{.State.Health.Status}}'
```

Result:

```text
healthy
```

Also verified inside the Proxmox container:

```bash
lxc-info -n 100
grep -n "cpuset" /var/lib/lxc/100/config || echo "no cpuset line"
grep -nE "cores|entrypoint" /etc/pve/lxc/100.conf || echo "no cores or entrypoint in CT config"
pct exec 100 -- ip a
pct exec 100 -- ss -lntp
curl -kI --connect-timeout 5 https://10.254.0.2
```

Confirmed:

* CT `100` is running.
* No invalid empty cpuset line is generated.
* Manager receives IP `10.254.0.2`.
* nginx listens on `80/443`.
* Manager app listens on `3000`.
* `curl` returns `HTTP/2 200`.

## Notes

On the first startup, the healthcheck may briefly fail while Manager finishes booting, but it later becomes healthy once nginx is listening on `443`.
