### PR TITLE
Container status API: compute live status instead of static DB column

### DIFF
--- a/create-a-container/README.md
+++ b/create-a-container/README.md
@@ -230,22 +230,20 @@ Delete a container from both Proxmox and the database
   - `403` - User doesn't own the container
   - `500` - Proxmox API deletion failed or node not configured
 
-#### `GET /api/v1/sites/:siteId/containers/:id/status` (Auth Required)
-Return the **live** status of a container, computed on demand rather than read
-from a stored column. The status is resolved by combining the container's
-presence/run-state in Proxmox, any active create/reconfigure jobs, and whether
-the live LXC config matches what the API server expects.
-- **Returns**: `{ data: { status } }` where `status` is one of:
-  - `running` — online in Proxmox
-  - `offline` — exists in Proxmox but stopped
-  - `creating` — no Proxmox VM yet, active create job
-  - `restarting` — active reconfigure job
-  - `failed` — no Proxmox VM, last create job failed
-  - `missing` — no Proxmox VM, create succeeded or no create job found
-  - `out-of-sync` — exists in Proxmox but its config differs from expectation
-  - `unknown` — Proxmox unreachable / node has no API credentials
-- **Note**: The same `status` value is also embedded on each container returned
-  by the list and show endpoints, so existing consumers remain non-breaking.
+#### Container status (`status` field)
+Every container returned by the list and show endpoints includes a **live**
+`status` field, computed on demand rather than read from a stored column. It is
+resolved by combining the container's presence/run-state in Proxmox, any active
+create/reconfigure jobs, and whether the live LXC config matches what the API
+server expects. Possible values:
+- `running` — online in Proxmox
+- `offline` — exists in Proxmox but stopped
+- `creating` — no Proxmox VM yet, active create job
+- `restarting` — active reconfigure job
+- `failed` — no Proxmox VM, last create job failed
+- `missing` — no Proxmox VM, create succeeded or no create job found
+- `out-of-sync` — exists in Proxmox but its config differs from expectation
+- `unknown` — Proxmox unreachable / node has no API credentials
 
 #### `GET /status/:jobId` (Auth Required)
 View container creation progress page

--- a/create-a-container/README.md
+++ b/create-a-container/README.md
@@ -22,7 +22,6 @@ erDiagram
         int id PK
         string hostname UK "FQDN hostname"
         string username "Owner username"
-        string status "pending,creating,running,failed"
         string template "Template name"
         int creationJobId FK "References Job"
         int nodeId FK "References Node"
@@ -230,6 +229,23 @@ Delete a container from both Proxmox and the database
   - `404` - Container not found
   - `403` - User doesn't own the container
   - `500` - Proxmox API deletion failed or node not configured
+
+#### `GET /api/v1/sites/:siteId/containers/:id/status` (Auth Required)
+Return the **live** status of a container, computed on demand rather than read
+from a stored column. The status is resolved by combining the container's
+presence/run-state in Proxmox, any active create/reconfigure jobs, and whether
+the live LXC config matches what the API server expects.
+- **Returns**: `{ data: { status } }` where `status` is one of:
+  - `running` — online in Proxmox
+  - `offline` — exists in Proxmox but stopped
+  - `creating` — no Proxmox VM yet, active create job
+  - `restarting` — active reconfigure job
+  - `failed` — no Proxmox VM, last create job failed
+  - `missing` — no Proxmox VM, create succeeded or no create job found
+  - `out-of-sync` — exists in Proxmox but its config differs from expectation
+  - `unknown` — Proxmox unreachable / node has no API credentials
+- **Note**: The same `status` value is also embedded on each container returned
+  by the list and show endpoints, so existing consumers remain non-breaking.
 
 #### `GET /status/:jobId` (Auth Required)
 View container creation progress page

--- a/create-a-container/README.md
+++ b/create-a-container/README.md
@@ -233,16 +233,14 @@ Delete a container from both Proxmox and the database
 #### Container status (`status` field)
 Every container returned by the list, show, and create endpoints includes a
 **live** `status` field, computed on demand rather than read from a stored
-column. It is resolved by combining the container's presence/run-state in
-Proxmox, any active create/reconfigure jobs, and whether the live LXC config
-matches what the API server expects. Possible values:
+column. It is resolved by combining the container's run-state in Proxmox (from a
+single per-node cluster snapshot) with the state of its create job. Possible
+values:
 - `running` — online in Proxmox
 - `offline` — exists in Proxmox but stopped
 - `creating` — no Proxmox VM yet, active create job
-- `restarting` — active reconfigure job
-- `failed` — no Proxmox VM, last create job failed
+- `failed` — no Proxmox VM, create job failed
 - `missing` — no Proxmox VM, create succeeded or no create job found
-- `out-of-sync` — exists in Proxmox but its config differs from expectation
 - `unknown` — Proxmox unreachable / node has no API credentials
 
 The create endpoint (`POST /containers`) returns `creating` immediately, since a

--- a/create-a-container/README.md
+++ b/create-a-container/README.md
@@ -231,11 +231,11 @@ Delete a container from both Proxmox and the database
   - `500` - Proxmox API deletion failed or node not configured
 
 #### Container status (`status` field)
-Every container returned by the list and show endpoints includes a **live**
-`status` field, computed on demand rather than read from a stored column. It is
-resolved by combining the container's presence/run-state in Proxmox, any active
-create/reconfigure jobs, and whether the live LXC config matches what the API
-server expects. Possible values:
+Every container returned by the list, show, and create endpoints includes a
+**live** `status` field, computed on demand rather than read from a stored
+column. It is resolved by combining the container's presence/run-state in
+Proxmox, any active create/reconfigure jobs, and whether the live LXC config
+matches what the API server expects. Possible values:
 - `running` — online in Proxmox
 - `offline` — exists in Proxmox but stopped
 - `creating` — no Proxmox VM yet, active create job
@@ -244,6 +244,9 @@ server expects. Possible values:
 - `missing` — no Proxmox VM, create succeeded or no create job found
 - `out-of-sync` — exists in Proxmox but its config differs from expectation
 - `unknown` — Proxmox unreachable / node has no API credentials
+
+The create endpoint (`POST /containers`) returns `creating` immediately, since a
+create job is enqueued and there is no Proxmox VM yet.
 
 #### `GET /status/:jobId` (Auth Required)
 View container creation progress page

--- a/create-a-container/bin/create-container.js
+++ b/create-a-container/bin/create-container.js
@@ -340,15 +340,8 @@ async function main() {
       console.log('Container configured');
     }
     
-    // Apply environment variables and entrypoint. buildLxcEnvConfig is the single
-    // source of truth for the effective env: it merges admin-defined system
-    // defaults and NVIDIA defaults under the user-defined values. None of this is
-    // written back into the DB record (see below).
+    // Apply environment variables and entrypoint
     const envConfig = await container.buildLxcEnvConfig();
-    // On a fresh container there is nothing to unset, so drop any 'delete' key to
-    // avoid a no-op API param.
-    delete envConfig.delete;
-
     if (Object.keys(envConfig).length > 0) {
       console.log('Applying environment variables and entrypoint...');
       await client.updateLxcConfig(node.name, vmid, envConfig);
@@ -418,11 +411,7 @@ async function main() {
       throw new Error('Could not get IP address from Proxmox interfaces API');
     }
     
-    // Update the container record. Note: environmentVars and entrypoint are NOT
-    // written back from the live config — the DB record stores only the values
-    // the user supplied. Admin-defined system defaults (and NVIDIA defaults) are
-    // merged in at configure-time and must not be persisted here, otherwise they
-    // would be frozen into the record and exposed in the edit UI.
+    // Update the container record
     console.log('Updating container record...');
     await container.update({
       macAddress,

--- a/create-a-container/bin/create-container.js
+++ b/create-a-container/bin/create-container.js
@@ -340,10 +340,20 @@ async function main() {
       console.log('Container configured');
     }
     
+    // Snapshot the template's env/entrypoint onto the container record now, as
+    // if the user had supplied them (user-supplied values still win). Templates
+    // are mutable Docker refs we can't re-query on a later reconfigure, so we
+    // persist them here; otherwise a future reconfigure (which uses
+    // deleteMissing) would unset template-provided values that were never
+    // stored. System/NVIDIA defaults are intentionally left out — they stay
+    // configure-time-only.
+    const templateConfig = await client.lxcConfig(node.name, vmid);
+    await container.persistTemplateDefaults(templateConfig);
+
     // Apply environment variables and entrypoint. Use the default
-    // (deleteMissing=false) so that any env/entrypoint provided by the template
-    // we just cloned is preserved when the user didn't supply their own — only
-    // explicit values are pushed, nothing is unset.
+    // (deleteMissing=false): only explicit values are pushed, nothing is unset.
+    // The record now already includes the template's values, and system/NVIDIA
+    // defaults are merged in by buildLxcEnvConfig.
     const envConfig = await container.buildLxcEnvConfig();
     if (Object.keys(envConfig).length > 0) {
       console.log('Applying environment variables and entrypoint...');

--- a/create-a-container/bin/create-container.js
+++ b/create-a-container/bin/create-container.js
@@ -340,23 +340,17 @@ async function main() {
       console.log('Container configured');
     }
     
-    // Apply environment variables and entrypoint.
-    // Admin-defined system defaults are merged in here, at configure-time, and are
-    // intentionally NOT written back into the container's DB record (see below).
-    // Precedence (lowest to highest): system defaults < NVIDIA defaults < user values.
-    // Image-provided env/entrypoint defaults are submitted by the UI as user values,
-    // so they already live in container.environmentVars / container.entrypoint.
-    const systemDefaultEnvVars = await Container.getSystemDefaultEnvVars();
-    const userEnvVars = container.parseEnvironmentVars();
-    const envConfig = container.buildLxcEnvConfig(systemDefaultEnvVars);
-    // buildLxcEnvConfig may add a 'delete' key to unset env/entrypoint; on a fresh
-    // container there is nothing to delete, so drop it to avoid a no-op API param.
+    // Apply environment variables and entrypoint. buildLxcEnvConfig is the single
+    // source of truth for the effective env: it merges admin-defined system
+    // defaults and NVIDIA defaults under the user-defined values. None of this is
+    // written back into the DB record (see below).
+    const envConfig = await container.buildLxcEnvConfig();
+    // On a fresh container there is nothing to unset, so drop any 'delete' key to
+    // avoid a no-op API param.
     delete envConfig.delete;
 
     if (Object.keys(envConfig).length > 0) {
       console.log('Applying environment variables and entrypoint...');
-      if (Object.keys(systemDefaultEnvVars).length > 0) console.log(`System default env vars: ${Object.keys(systemDefaultEnvVars).length} from settings`);
-      if (Object.keys(userEnvVars).length > 0) console.log(`Per-container env vars: ${Object.keys(userEnvVars).length}`);
       await client.updateLxcConfig(node.name, vmid, envConfig);
       console.log('Environment/entrypoint configuration applied');
     }

--- a/create-a-container/bin/create-container.js
+++ b/create-a-container/bin/create-container.js
@@ -340,7 +340,10 @@ async function main() {
       console.log('Container configured');
     }
     
-    // Apply environment variables and entrypoint
+    // Apply environment variables and entrypoint. Use the default
+    // (deleteMissing=false) so that any env/entrypoint provided by the template
+    // we just cloned is preserved when the user didn't supply their own — only
+    // explicit values are pushed, nothing is unset.
     const envConfig = await container.buildLxcEnvConfig();
     if (Object.keys(envConfig).length > 0) {
       console.log('Applying environment variables and entrypoint...');

--- a/create-a-container/bin/create-container.js
+++ b/create-a-container/bin/create-container.js
@@ -177,9 +177,14 @@ async function main() {
     console.error(`Container with ID ${containerId} not found`);
     process.exit(1);
   }
-  
-  if (container.status !== 'pending') {
-    console.error(`Container is not in pending status (current: ${container.status})`);
+
+  // Guard against double-provisioning. The status column no longer exists, so
+  // we use the Proxmox VMID as the signal: once a VMID has been allocated and
+  // stored, creation has already run for this container.
+  if (container.containerId) {
+    console.error(
+      `Container already has a Proxmox VMID (${container.containerId}); refusing to re-create`,
+    );
     process.exit(1);
   }
   
@@ -217,10 +222,6 @@ async function main() {
   console.log(`Template type: ${isDocker ? 'Docker image' : 'Proxmox template'}`);
   
   try {
-    // Update status to 'creating'
-    await container.update({ status: 'creating' });
-    console.log('Status updated to: creating');
-    
     // Get the Proxmox API client
     const client = await node.api();
     console.log('Proxmox API client initialized');
@@ -428,8 +429,7 @@ async function main() {
     console.log('Updating container record...');
     await container.update({
       macAddress,
-      ipv4Address,
-      status: 'running'
+      ipv4Address
     });
     
     console.log('Container creation completed successfully!');
@@ -480,15 +480,10 @@ async function main() {
     if (err.response?.data) {
       console.error('API Error Details:', JSON.stringify(err.response.data, null, 2));
     }
-    
-    // Update status to failed
-    try {
-      await container.update({ status: 'failed' });
-      console.log('Status updated to: failed');
-    } catch (updateErr) {
-      console.error('Failed to update container status:', updateErr.message);
-    }
-    
+
+    // The container status is no longer persisted. Failure is recorded by the
+    // job-runner marking this job 'failure'; the live status resolver maps a
+    // missing-in-Proxmox container whose last create job failed to 'failed'.
     process.exit(1);
   }
 }

--- a/create-a-container/bin/create-container.js
+++ b/create-a-container/bin/create-container.js
@@ -481,9 +481,6 @@ async function main() {
       console.error('API Error Details:', JSON.stringify(err.response.data, null, 2));
     }
 
-    // The container status is no longer persisted. Failure is recorded by the
-    // job-runner marking this job 'failure'; the live status resolver maps a
-    // missing-in-Proxmox container whose last create job failed to 'failed'.
     process.exit(1);
   }
 }

--- a/create-a-container/bin/create-container.js
+++ b/create-a-container/bin/create-container.js
@@ -340,62 +340,21 @@ async function main() {
       console.log('Container configured');
     }
     
-    // Apply environment variables and entrypoint
-    // First read defaults from the image, then merge with user-specified values
-    const defaultConfig = await client.lxcConfig(node.name, vmid);
-    const defaultEntrypoint = defaultConfig['entrypoint'] || null;
-    const defaultEnvStr = defaultConfig['env'] || null;
-    
-    // Parse default env vars
-    let mergedEnvVars = {};
-    if (defaultEnvStr) {
-      const pairs = defaultEnvStr.split('\0');
-      for (const pair of pairs) {
-        const eqIndex = pair.indexOf('=');
-        if (eqIndex > 0) {
-          mergedEnvVars[pair.substring(0, eqIndex)] = pair.substring(eqIndex + 1);
-        }
-      }
-    }
-    
-    // Merge user-specified env vars (user values override defaults)
-    const userEnvVars = container.environmentVars ? JSON.parse(container.environmentVars) : {};
+    // Apply environment variables and entrypoint.
+    // Admin-defined system defaults are merged in here, at configure-time, and are
+    // intentionally NOT written back into the container's DB record (see below).
+    // Precedence (lowest to highest): system defaults < NVIDIA defaults < user values.
+    // Image-provided env/entrypoint defaults are submitted by the UI as user values,
+    // so they already live in container.environmentVars / container.entrypoint.
+    const systemDefaultEnvVars = await Container.getSystemDefaultEnvVars();
+    const userEnvVars = container.parseEnvironmentVars();
+    const envConfig = container.buildLxcEnvConfig(systemDefaultEnvVars);
+    // buildLxcEnvConfig may add a 'delete' key to unset env/entrypoint; on a fresh
+    // container there is nothing to delete, so drop it to avoid a no-op API param.
+    delete envConfig.delete;
 
-    // Load system-wide default env vars from Settings.
-    // Descriptions are metadata only and are not passed into the container.
-    let systemDefaultEnvVars = {};
-    try {
-      const entries = await Setting.getDefaultContainerEnvVars();
-      for (const entry of entries) {
-        if (entry.key && entry.key.trim()) {
-          systemDefaultEnvVars[entry.key.trim()] = entry.value || '';
-        }
-      }
-    } catch (_) {
-      console.warn('Could not load default_container_env_vars from settings, skipping');
-    }
-
-    // Merge priority: image defaults < system defaults < per-container user values
-    mergedEnvVars = { ...mergedEnvVars, ...systemDefaultEnvVars, ...userEnvVars };
-    
-    // Use user entrypoint if specified, otherwise keep default
-    const finalEntrypoint = container.entrypoint || defaultEntrypoint;
-    
-    // Build config to apply
-    const envConfig = {};
-    if (finalEntrypoint) {
-      envConfig.entrypoint = finalEntrypoint;
-    }
-    if (Object.keys(mergedEnvVars).length > 0) {
-      envConfig.env = Object.entries(mergedEnvVars)
-        .map(([key, value]) => `${key}=${value}`)
-        .join('\0');
-    }
-    
     if (Object.keys(envConfig).length > 0) {
       console.log('Applying environment variables and entrypoint...');
-      if (defaultEntrypoint) console.log(`Default entrypoint: ${defaultEntrypoint}`);
-      if (defaultEnvStr) console.log(`Image default env vars: ${Object.keys(mergedEnvVars).length - Object.keys(userEnvVars).length - Object.keys(systemDefaultEnvVars).length}`);
       if (Object.keys(systemDefaultEnvVars).length > 0) console.log(`System default env vars: ${Object.keys(systemDefaultEnvVars).length} from settings`);
       if (Object.keys(userEnvVars).length > 0) console.log(`Per-container env vars: ${Object.keys(userEnvVars).length}`);
       await client.updateLxcConfig(node.name, vmid, envConfig);
@@ -447,11 +406,9 @@ async function main() {
       throw new Error('Could not extract MAC address from container configuration');
     }
     
-    // Read back entrypoint and environment variables from config
+    // Read back configuration from Proxmox.
     console.log('Querying container configuration...');
     const config = await client.lxcConfig(node.name, vmid);
-    const actualEntrypoint = config['entrypoint'] || null;
-    const actualEnv = config['env'] || null;
 
     // Read back the actual provisioned resources so downstream systems
     // (e.g. NetBox) mirror what the container really has rather than assuming
@@ -459,28 +416,7 @@ async function main() {
     const actualCores = config['cores'] != null ? parseInt(config['cores'], 10) : null;
     const actualMemoryMb = config['memory'] != null ? parseInt(config['memory'], 10) : null;
     const actualDiskGb = parseRootfsSizeGb(config['rootfs']);
-    
-    // Parse NUL-separated env string back to JSON object
-    let environmentVars = {};
-    if (actualEnv) {
-      const pairs = actualEnv.split('\0');
-      for (const pair of pairs) {
-        const eqIndex = pair.indexOf('=');
-        if (eqIndex > 0) {
-          const key = pair.substring(0, eqIndex);
-          const value = pair.substring(eqIndex + 1);
-          environmentVars[key] = value;
-        }
-      }
-    }
-    
-    if (actualEntrypoint) {
-      console.log(`Entrypoint: ${actualEntrypoint}`);
-    }
-    if (Object.keys(environmentVars).length > 0) {
-      console.log(`Environment variables: ${Object.keys(environmentVars).length} vars`);
-    }
-    
+
     // Get IP address from Proxmox interfaces API
     const ipv4Address = await client.getLxcIpAddress(node.name, vmid);
     
@@ -488,13 +424,15 @@ async function main() {
       throw new Error('Could not get IP address from Proxmox interfaces API');
     }
     
-    // Update the container record
+    // Update the container record. Note: environmentVars and entrypoint are NOT
+    // written back from the live config — the DB record stores only the values
+    // the user supplied. Admin-defined system defaults (and NVIDIA defaults) are
+    // merged in at configure-time and must not be persisted here, otherwise they
+    // would be frozen into the record and exposed in the edit UI.
     console.log('Updating container record...');
     await container.update({
       macAddress,
       ipv4Address,
-      entrypoint: actualEntrypoint,
-      environmentVars: JSON.stringify(environmentVars),
       status: 'running'
     });
     

--- a/create-a-container/bin/json-to-sql.js
+++ b/create-a-container/bin/json-to-sql.js
@@ -222,7 +222,6 @@ async function run() {
         hostname,
         ipv4Address: obj.ip,
         username: obj.user || '',
-        status: 'running',
         template: obj.template || null,
         containerId: obj.ctid,
         macAddress: obj.mac,
@@ -234,7 +233,6 @@ async function run() {
       await container.update({
         ipv4Address: obj.ip,
         username: obj.user || '',
-        status: container.status || 'running',
         template: obj.template || container.template,
         containerId: obj.ctid,
         macAddress: obj.mac

--- a/create-a-container/bin/reconfigure-container.js
+++ b/create-a-container/bin/reconfigure-container.js
@@ -160,14 +160,13 @@ async function main() {
         throw new Error('Could not get IP address from Proxmox interfaces API');
       }
 
-      // Update container record with MAC/IP and running status
+      // Update container record with MAC/IP (status is no longer persisted)
       await container.update({
-        status: 'running',
         macAddress,
         ipv4Address
       });
 
-      console.log('Status updated to: running');
+      console.log('Reconfiguration applied; container running');
       console.log(`  MAC: ${macAddress}`);
       console.log(`  IP: ${ipv4Address}`);
     }
@@ -181,15 +180,9 @@ async function main() {
     if (err.response?.data) {
       console.error('API Error Details:', JSON.stringify(err.response.data, null, 2));
     }
-    
-    // Update status to failed
-    try {
-      await container.update({ status: 'failed' });
-      console.log('Status updated to: failed');
-    } catch (updateErr) {
-      console.error('Failed to update container status:', updateErr.message);
-    }
-    
+
+    // Container status is no longer persisted. The job-runner records this job as
+    // 'failure'; live status is derived from Proxmox + job state on read.
     process.exit(1);
   }
 }

--- a/create-a-container/bin/reconfigure-container.js
+++ b/create-a-container/bin/reconfigure-container.js
@@ -80,16 +80,11 @@ async function main() {
     const client = await node.api();
     console.log('Proxmox API client initialized');
     
-    // Merge admin-defined default environment variables at configure-time rather
-    // than storing them in the container's DB record. Precedence (lowest to
-    // highest): system defaults < NVIDIA defaults < user-defined values.
-    // (NVIDIA and user-defined are applied inside buildLxcEnvConfig.)
-    // Image-provided defaults are submitted by the UI as user-defined values, so
-    // they are already part of container.environmentVars and not handled here.
-    const systemDefaultEnvVars = await Container.getSystemDefaultEnvVars();
-
-    // Build config from environment variables and entrypoint, merging defaults
-    const lxcConfig = container.buildLxcEnvConfig(systemDefaultEnvVars);
+    // Build config from environment variables and entrypoint. buildLxcEnvConfig
+    // is the single source of truth for the effective env: it merges admin-defined
+    // system defaults and NVIDIA defaults under the user-defined values, applied
+    // here at configure-time rather than stored in the DB record.
+    const lxcConfig = await container.buildLxcEnvConfig();
     
     if (Object.keys(lxcConfig).length > 0) {
       console.log('Applying LXC configuration...');

--- a/create-a-container/bin/reconfigure-container.js
+++ b/create-a-container/bin/reconfigure-container.js
@@ -80,10 +80,7 @@ async function main() {
     const client = await node.api();
     console.log('Proxmox API client initialized');
     
-    // Build config from environment variables and entrypoint. buildLxcEnvConfig
-    // is the single source of truth for the effective env: it merges admin-defined
-    // system defaults and NVIDIA defaults under the user-defined values, applied
-    // here at configure-time rather than stored in the DB record.
+    // Build config from environment variables and entrypoint
     const lxcConfig = await container.buildLxcEnvConfig();
     
     if (Object.keys(lxcConfig).length > 0) {

--- a/create-a-container/bin/reconfigure-container.js
+++ b/create-a-container/bin/reconfigure-container.js
@@ -80,8 +80,11 @@ async function main() {
     const client = await node.api();
     console.log('Proxmox API client initialized');
     
-    // Build config from environment variables and entrypoint
-    const lxcConfig = await container.buildLxcEnvConfig();
+    // Build config from environment variables and entrypoint. Pass
+    // deleteMissing so that clearing env vars or removing a custom entrypoint
+    // actually unsets them on the existing container (vs. create, which must
+    // preserve template-provided values).
+    const lxcConfig = await container.buildLxcEnvConfig({ deleteMissing: true });
     
     if (Object.keys(lxcConfig).length > 0) {
       console.log('Applying LXC configuration...');

--- a/create-a-container/bin/reconfigure-container.js
+++ b/create-a-container/bin/reconfigure-container.js
@@ -80,8 +80,16 @@ async function main() {
     const client = await node.api();
     console.log('Proxmox API client initialized');
     
-    // Build config from environment variables and entrypoint
-    const lxcConfig = container.buildLxcEnvConfig();
+    // Merge admin-defined default environment variables at configure-time rather
+    // than storing them in the container's DB record. Precedence (lowest to
+    // highest): system defaults < NVIDIA defaults < user-defined values.
+    // (NVIDIA and user-defined are applied inside buildLxcEnvConfig.)
+    // Image-provided defaults are submitted by the UI as user-defined values, so
+    // they are already part of container.environmentVars and not handled here.
+    const systemDefaultEnvVars = await Container.getSystemDefaultEnvVars();
+
+    // Build config from environment variables and entrypoint, merging defaults
+    const lxcConfig = container.buildLxcEnvConfig(systemDefaultEnvVars);
     
     if (Object.keys(lxcConfig).length > 0) {
       console.log('Applying LXC configuration...');

--- a/create-a-container/bin/reconfigure-container.js
+++ b/create-a-container/bin/reconfigure-container.js
@@ -160,7 +160,7 @@ async function main() {
         throw new Error('Could not get IP address from Proxmox interfaces API');
       }
 
-      // Update container record with MAC/IP (status is no longer persisted)
+      // Update container record with MAC/IP
       await container.update({
         macAddress,
         ipv4Address
@@ -181,8 +181,6 @@ async function main() {
       console.error('API Error Details:', JSON.stringify(err.response.data, null, 2));
     }
 
-    // Container status is no longer persisted. The job-runner records this job as
-    // 'failure'; live status is derived from Proxmox + job state on read.
     process.exit(1);
   }
 }

--- a/create-a-container/client/src/lib/queries.ts
+++ b/create-a-container/client/src/lib/queries.ts
@@ -8,6 +8,7 @@ import type {
   Container,
   ContainerMetadata,
   ContainerNewBootstrap,
+  ContainerStatusResult,
   EffectiveResources,
   ExternalDomain,
   Group,
@@ -29,6 +30,8 @@ export const keys = {
   containers: (siteId: number | string) => ['sites', String(siteId), 'containers'] as const,
   container: (siteId: number | string, id: number | string) =>
     ['sites', String(siteId), 'containers', String(id)] as const,
+  containerStatus: (siteId: number | string, id: number | string) =>
+    ['sites', String(siteId), 'containers', String(id), 'status'] as const,
   containerBootstrap: (siteId: number | string) =>
     ['sites', String(siteId), 'containers', 'new'] as const,
   containerMetadata: (image: string) => ['container-metadata', image] as const,
@@ -64,6 +67,8 @@ export const queries = {
     api.get<Container[]>(`/api/v1/sites/${siteId}/containers`),
   getContainer: (siteId: number | string, id: number | string) =>
     api.get<Container>(`/api/v1/sites/${siteId}/containers/${id}`),
+  getContainerStatus: (siteId: number | string, id: number | string) =>
+    api.get<ContainerStatusResult>(`/api/v1/sites/${siteId}/containers/${id}/status`),
   containerBootstrap: (siteId: number | string) =>
     api.get<ContainerNewBootstrap>(`/api/v1/sites/${siteId}/containers/new`),
   containerMetadata: (siteId: number | string, image: string) =>

--- a/create-a-container/client/src/lib/queries.ts
+++ b/create-a-container/client/src/lib/queries.ts
@@ -8,7 +8,6 @@ import type {
   Container,
   ContainerMetadata,
   ContainerNewBootstrap,
-  ContainerStatusResult,
   EffectiveResources,
   ExternalDomain,
   Group,
@@ -30,8 +29,6 @@ export const keys = {
   containers: (siteId: number | string) => ['sites', String(siteId), 'containers'] as const,
   container: (siteId: number | string, id: number | string) =>
     ['sites', String(siteId), 'containers', String(id)] as const,
-  containerStatus: (siteId: number | string, id: number | string) =>
-    ['sites', String(siteId), 'containers', String(id), 'status'] as const,
   containerBootstrap: (siteId: number | string) =>
     ['sites', String(siteId), 'containers', 'new'] as const,
   containerMetadata: (image: string) => ['container-metadata', image] as const,
@@ -67,8 +64,6 @@ export const queries = {
     api.get<Container[]>(`/api/v1/sites/${siteId}/containers`),
   getContainer: (siteId: number | string, id: number | string) =>
     api.get<Container>(`/api/v1/sites/${siteId}/containers/${id}`),
-  getContainerStatus: (siteId: number | string, id: number | string) =>
-    api.get<ContainerStatusResult>(`/api/v1/sites/${siteId}/containers/${id}/status`),
   containerBootstrap: (siteId: number | string) =>
     api.get<ContainerNewBootstrap>(`/api/v1/sites/${siteId}/containers/new`),
   containerMetadata: (siteId: number | string, image: string) =>

--- a/create-a-container/client/src/lib/types.ts
+++ b/create-a-container/client/src/lib/types.ts
@@ -92,7 +92,7 @@ export interface Container {
 
 /**
  * Live container status resolved from Proxmox + job state + config drift.
- * Returned by GET /sites/:id/containers/:id/status and embedded on Container.
+ * Embedded on each Container returned by the list/show/create endpoints.
  */
 export type ContainerStatus =
   | 'running'
@@ -103,10 +103,6 @@ export type ContainerStatus =
   | 'missing'
   | 'out-of-sync'
   | 'unknown';
-
-export interface ContainerStatusResult {
-  status: ContainerStatus;
-}
 
 export interface ContainerCreateResult {
   containerId: number;

--- a/create-a-container/client/src/lib/types.ts
+++ b/create-a-container/client/src/lib/types.ts
@@ -91,17 +91,15 @@ export interface Container {
 }
 
 /**
- * Live container status resolved from Proxmox + job state + config drift.
+ * Live container status resolved from Proxmox run-state + create-job state.
  * Embedded on each Container returned by the list/show/create endpoints.
  */
 export type ContainerStatus =
   | 'running'
   | 'offline'
   | 'creating'
-  | 'restarting'
   | 'failed'
   | 'missing'
-  | 'out-of-sync'
   | 'unknown';
 
 export interface ContainerCreateResult {

--- a/create-a-container/client/src/lib/types.ts
+++ b/create-a-container/client/src/lib/types.ts
@@ -75,7 +75,7 @@ export interface Container {
   hostname: string;
   ipv4Address: string | null;
   macAddress: string | null;
-  status: string;
+  status: ContainerStatus;
   template: string | null;
   creationJobId: number | null;
   entrypoint: string | null;
@@ -90,11 +90,29 @@ export interface Container {
   createdAt: string;
 }
 
+/**
+ * Live container status resolved from Proxmox + job state + config drift.
+ * Returned by GET /sites/:id/containers/:id/status and embedded on Container.
+ */
+export type ContainerStatus =
+  | 'running'
+  | 'offline'
+  | 'creating'
+  | 'restarting'
+  | 'failed'
+  | 'missing'
+  | 'out-of-sync'
+  | 'unknown';
+
+export interface ContainerStatusResult {
+  status: ContainerStatus;
+}
+
 export interface ContainerCreateResult {
   containerId: number;
   jobId: number;
   hostname: string;
-  status: string;
+  status: ContainerStatus;
 }
 
 export interface ContainerNewBootstrap {

--- a/create-a-container/client/src/pages/containers/ContainersListPage.tsx
+++ b/create-a-container/client/src/pages/containers/ContainersListPage.tsx
@@ -46,8 +46,6 @@ function statusVariant(
     case 'running':
       return 'success';
     case 'creating':
-    case 'restarting':
-    case 'out-of-sync':
       return 'warning';
     case 'failed':
       return 'danger';
@@ -64,10 +62,8 @@ const STATUS_LABELS: Record<ContainerStatus, string> = {
   running: 'Running',
   offline: 'Offline',
   creating: 'Creating',
-  restarting: 'Restarting',
   failed: 'Failed',
   missing: 'Missing',
-  'out-of-sync': 'Out of sync',
   unknown: 'Unknown',
 };
 

--- a/create-a-container/client/src/pages/containers/ContainersListPage.tsx
+++ b/create-a-container/client/src/pages/containers/ContainersListPage.tsx
@@ -34,26 +34,74 @@ import {
 import { api, ApiError } from '@/lib/api';
 import { useSession } from '@/lib/auth';
 import { keys, queries } from '@/lib/queries';
-import type { Container } from '@/lib/types';
+import type { Container, ContainerStatus } from '@/lib/types';
 
 type ViewMode = 'cards' | 'table';
 const VIEW_STORAGE_KEY = 'containers:view';
 
-function statusVariant(s: string): 'default' | 'success' | 'warning' | 'danger' | 'secondary' {
+function statusVariant(
+  s: ContainerStatus,
+): 'default' | 'success' | 'warning' | 'danger' | 'secondary' {
   switch (s) {
     case 'running':
       return 'success';
-    case 'pending':
+    case 'creating':
     case 'restarting':
       return 'warning';
     case 'failed':
-    case 'error':
+    case 'out-of-sync':
       return 'danger';
-    case 'stopped':
+    case 'offline':
+    case 'missing':
       return 'secondary';
     default:
       return 'default';
   }
+}
+
+// Human-readable labels for the live status values.
+const STATUS_LABELS: Record<ContainerStatus, string> = {
+  running: 'Running',
+  offline: 'Offline',
+  creating: 'Creating',
+  restarting: 'Restarting',
+  failed: 'Failed',
+  missing: 'Missing',
+  'out-of-sync': 'Out of sync',
+  unknown: 'Unknown',
+};
+
+// Statuses that are transitional and worth polling for.
+const TRANSITIONAL_STATUSES: ReadonlySet<ContainerStatus> = new Set<ContainerStatus>([
+  'creating',
+  'restarting',
+]);
+
+/**
+ * Live status badge. Per issue #350 each row queries the dedicated
+ * /containers/:id/status endpoint. The status already returned by the list
+ * endpoint seeds initialData so the badge paints instantly, then this query
+ * keeps it fresh (polling while the container is in a transitional state).
+ */
+function ContainerStatusBadge({
+  siteId,
+  container,
+}: {
+  siteId: string | undefined;
+  container: Container;
+}) {
+  const { data } = useQuery({
+    queryKey: keys.containerStatus(siteId!, container.id),
+    queryFn: () => queries.getContainerStatus(siteId!, container.id),
+    enabled: !!siteId,
+    initialData: { status: container.status },
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status && TRANSITIONAL_STATUSES.has(status) ? 4000 : false;
+    },
+  });
+  const status = data?.status ?? container.status;
+  return <Badge variant={statusVariant(status)}>{STATUS_LABELS[status] ?? status}</Badge>;
 }
 
 const linkClass = 'text-(--color-primary,#1d4ed8) hover:underline';
@@ -330,7 +378,7 @@ export function ContainersListPage() {
                 <CardTitle as="h2" className="truncate text-sm font-semibold">
                   {c.hostname}
                 </CardTitle>
-                <Badge variant={statusVariant(c.status)}>{c.status}</Badge>
+                <ContainerStatusBadge siteId={siteId} container={c} />
               </div>
               <div className="ml-auto flex shrink-0 items-center gap-1 lg:order-3 lg:ml-0">
                 <RowActions c={c} siteId={siteId} onDelete={del.mutate} deleting={del.isPending} />
@@ -374,7 +422,7 @@ export function ContainersListPage() {
               <TableRow key={c.id}>
                 <TableCell className="font-medium">{c.hostname}</TableCell>
                 <TableCell>
-                  <Badge variant={statusVariant(c.status)}>{c.status}</Badge>
+                  <ContainerStatusBadge siteId={siteId} container={c} />
                 </TableCell>
                 <TableCell>
                   <NodeLink c={c} />

--- a/create-a-container/client/src/pages/containers/ContainersListPage.tsx
+++ b/create-a-container/client/src/pages/containers/ContainersListPage.tsx
@@ -47,9 +47,9 @@ function statusVariant(
       return 'success';
     case 'creating':
     case 'restarting':
+    case 'out-of-sync':
       return 'warning';
     case 'failed':
-    case 'out-of-sync':
       return 'danger';
     case 'offline':
     case 'missing':

--- a/create-a-container/client/src/pages/containers/ContainersListPage.tsx
+++ b/create-a-container/client/src/pages/containers/ContainersListPage.tsx
@@ -71,36 +71,8 @@ const STATUS_LABELS: Record<ContainerStatus, string> = {
   unknown: 'Unknown',
 };
 
-// Statuses that are transitional and worth polling for.
-const TRANSITIONAL_STATUSES: ReadonlySet<ContainerStatus> = new Set<ContainerStatus>([
-  'creating',
-  'restarting',
-]);
-
-/**
- * Live status badge. Per issue #350 each row queries the dedicated
- * /containers/:id/status endpoint. The status already returned by the list
- * endpoint seeds initialData so the badge paints instantly, then this query
- * keeps it fresh (polling while the container is in a transitional state).
- */
-function ContainerStatusBadge({
-  siteId,
-  container,
-}: {
-  siteId: string | undefined;
-  container: Container;
-}) {
-  const { data } = useQuery({
-    queryKey: keys.containerStatus(siteId!, container.id),
-    queryFn: () => queries.getContainerStatus(siteId!, container.id),
-    enabled: !!siteId,
-    initialData: { status: container.status },
-    refetchInterval: (query) => {
-      const status = query.state.data?.status;
-      return status && TRANSITIONAL_STATUSES.has(status) ? 4000 : false;
-    },
-  });
-  const status = data?.status ?? container.status;
+/** Status badge. The status is the live value embedded in the list response. */
+function StatusBadge({ status }: { status: ContainerStatus }) {
   return <Badge variant={statusVariant(status)}>{STATUS_LABELS[status] ?? status}</Badge>;
 }
 
@@ -378,7 +350,7 @@ export function ContainersListPage() {
                 <CardTitle as="h2" className="truncate text-sm font-semibold">
                   {c.hostname}
                 </CardTitle>
-                <ContainerStatusBadge siteId={siteId} container={c} />
+                <StatusBadge status={c.status} />
               </div>
               <div className="ml-auto flex shrink-0 items-center gap-1 lg:order-3 lg:ml-0">
                 <RowActions c={c} siteId={siteId} onDelete={del.mutate} deleting={del.isPending} />
@@ -422,7 +394,7 @@ export function ContainersListPage() {
               <TableRow key={c.id}>
                 <TableCell className="font-medium">{c.hostname}</TableCell>
                 <TableCell>
-                  <ContainerStatusBadge siteId={siteId} container={c} />
+                  <StatusBadge status={c.status} />
                 </TableCell>
                 <TableCell>
                   <NodeLink c={c} />

--- a/create-a-container/migrations/20260615000000-remove-container-status.js
+++ b/create-a-container/migrations/20260615000000-remove-container-status.js
@@ -5,8 +5,8 @@
  * Remove the static `status` column from Containers.
  *
  * Container status is now computed live from Proxmox + job state + config drift
- * (see utils/container-status.js and GET /sites/:id/containers/:id/status), so the
- * persisted column is no longer a source of truth and is dropped.
+ * (see utils/container-status.js) and embedded on the container API payloads, so
+ * the persisted column is no longer a source of truth and is dropped.
  *
  * The down migration restores the column (defaulting to 'running') for rollback,
  * but the historical per-container value cannot be recovered.

--- a/create-a-container/migrations/20260615000000-remove-container-status.js
+++ b/create-a-container/migrations/20260615000000-remove-container-status.js
@@ -1,0 +1,26 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+
+/**
+ * Remove the static `status` column from Containers.
+ *
+ * Container status is now computed live from Proxmox + job state + config drift
+ * (see utils/container-status.js and GET /sites/:id/containers/:id/status), so the
+ * persisted column is no longer a source of truth and is dropped.
+ *
+ * The down migration restores the column (defaulting to 'running') for rollback,
+ * but the historical per-container value cannot be recovered.
+ */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.removeColumn('Containers', 'status');
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Containers', 'status', {
+      type: Sequelize.STRING(20),
+      allowNull: false,
+      defaultValue: 'running',
+    });
+  },
+};

--- a/create-a-container/models/container.js
+++ b/create-a-container/models/container.js
@@ -21,37 +21,100 @@ module.exports = (sequelize, DataTypes) => {
     }
 
     /**
-     * Build LXC config object for environment variables and entrypoint
-     * Returns config suitable for Proxmox API updateLxcConfig
+     * Load the admin-defined system default environment variables from the
+     * Settings table, flattened to a { KEY: value } object. Descriptions are
+     * metadata only and are not included. Returns an empty object if the
+     * setting is missing or malformed.
+     * @returns {Promise<object>} Flat object of { KEY: value } system defaults
+     */
+    static async getSystemDefaultEnvVars() {
+      const Setting = this.sequelize.models.Setting;
+      const defaults = {};
+      try {
+        const entries = await Setting.getDefaultContainerEnvVars();
+        for (const entry of entries) {
+          if (entry.key && entry.key.trim()) {
+            defaults[entry.key.trim()] = entry.value || '';
+          }
+        }
+      } catch (_) {
+        console.warn('Could not load default_container_env_vars from settings, skipping');
+      }
+      return defaults;
+    }
+
+    /**
+     * Parse the container's user-defined environment variables.
+     * The database record only ever stores the variables the user explicitly
+     * provided — admin/system, image, and NVIDIA defaults are merged in at
+     * configure-time (see buildLxcEnvConfig) and are intentionally NOT persisted.
+     * @returns {object} Flat object of { KEY: value } user-defined env vars
+     */
+    parseEnvironmentVars() {
+      if (!this.environmentVars) return {};
+      try {
+        const parsed = JSON.parse(this.environmentVars);
+        return parsed && typeof parsed === 'object' ? parsed : {};
+      } catch (err) {
+        console.error('Failed to parse environment variables JSON:', err.message);
+        return {};
+      }
+    }
+
+    /**
+     * Environment variables implied by this container's configuration that are
+     * applied as defaults but never stored in the DB record. Currently this is
+     * the NVIDIA GPU passthrough defaults, applied when nvidiaRequested is set.
+     * @returns {object} Flat object of { KEY: value } defaults
+     */
+    nvidiaDefaultEnvVars() {
+      if (!this.nvidiaRequested) return {};
+      return {
+        NVIDIA_VISIBLE_DEVICES: 'all',
+        NVIDIA_DRIVER_CAPABILITIES: 'utility compute'
+      };
+    }
+
+    /**
+     * Build LXC config object for environment variables and entrypoint.
+     * Returns config suitable for Proxmox API updateLxcConfig.
+     *
+     * Default environment variables are merged in here, at configure-time,
+     * rather than being baked into the container's DB record. User-defined
+     * variables take precedence over any provided defaults.
+     *
+     * @param {object} [defaults={}] - Flat object of default env vars, e.g. the
+     *   admin-defined system defaults. User-defined values and this container's
+     *   own NVIDIA defaults override these.
      * @returns {object} Config object with 'env' and 'entrypoint' properties
      */
-    buildLxcEnvConfig() {
+    buildLxcEnvConfig(defaults = {}) {
       const config = {};
       const deleteList = [];
-      
-      // Parse environment variables from JSON and format as NUL-separated list
-      // Format: KEY1=value1\0KEY2=value2\0KEY3=value3
-      if (this.environmentVars) {
-        try {
-          const envObj = JSON.parse(this.environmentVars);
-          const envPairs = [];
-          for (const [key, value] of Object.entries(envObj)) {
-            if (key && value !== undefined) {
-              envPairs.push(`${key}=${value}`);
-            }
-          }
-          if (envPairs.length > 0) {
-            config['env'] = envPairs.join('\0');
-          } else {
-            deleteList.push('env');
-          }
-        } catch (err) {
-          console.error('Failed to parse environment variables JSON:', err.message);
+
+      // Merge precedence (lowest to highest):
+      //   provided defaults (admin-defined system defaults) < NVIDIA defaults
+      //   < user-defined values
+      const userEnvVars = this.parseEnvironmentVars();
+      const mergedEnvVars = {
+        ...(defaults && typeof defaults === 'object' ? defaults : {}),
+        ...this.nvidiaDefaultEnvVars(),
+        ...userEnvVars
+      };
+
+      // Format as NUL-separated list: KEY1=value1\0KEY2=value2\0KEY3=value3
+      const envPairs = [];
+      for (const [key, value] of Object.entries(mergedEnvVars)) {
+        if (key && value !== undefined) {
+          envPairs.push(`${key}=${value}`);
         }
+      }
+      if (envPairs.length > 0) {
+        config['env'] = envPairs.join('\0');
       } else {
         deleteList.push('env');
       }
-      
+
       // Set entrypoint command
       if (this.entrypoint && this.entrypoint.trim()) {
         config['entrypoint'] = this.entrypoint.trim();

--- a/create-a-container/models/container.js
+++ b/create-a-container/models/container.js
@@ -268,11 +268,6 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING(255),
       allowNull: false
     },
-    status: {
-      type: DataTypes.STRING(20),
-      allowNull: false,
-      defaultValue: 'pending'
-    },
     template: {
       type: DataTypes.STRING(255),
       allowNull: true

--- a/create-a-container/models/container.js
+++ b/create-a-container/models/container.js
@@ -64,6 +64,24 @@ module.exports = (sequelize, DataTypes) => {
     }
 
     /**
+     * Parse a Proxmox LXC `env` string (NUL-separated `KEY=value` pairs) into a
+     * normalized, flat { KEY: stringValue } object. Anything malformed is
+     * dropped via normalizeEnvVars. The inverse of the encoding done in
+     * buildLxcEnvConfig.
+     * @param {string|null|undefined} envStr - Raw Proxmox `env` value
+     * @returns {object} Flat object of validated { KEY: value }
+     */
+    static parseLxcEnvString(envStr) {
+      if (!envStr || typeof envStr !== 'string') return {};
+      const raw = {};
+      for (const pair of envStr.split('\0')) {
+        const eq = pair.indexOf('=');
+        if (eq > 0) raw[pair.substring(0, eq)] = pair.substring(eq + 1);
+      }
+      return this.normalizeEnvVars(raw);
+    }
+
+    /**
      * Internal helper for buildLxcEnvConfig.
      * Load the admin-defined system default environment variables from the
      * Settings table, flattened to a validated { KEY: value } object.
@@ -120,6 +138,46 @@ module.exports = (sequelize, DataTypes) => {
         NVIDIA_VISIBLE_DEVICES: 'all',
         NVIDIA_DRIVER_CAPABILITIES: 'utility compute'
       };
+    }
+
+    /**
+     * Fold a template's environment variables and entrypoint into this
+     * container's persisted record, as if the user had supplied them.
+     *
+     * Called once at creation, after the template has been cloned, with the
+     * template's own LXC config. We can't recover these values later (templates
+     * are mutable Docker refs that may change or disappear before a reconfigure,
+     * and we don't cache them), so we snapshot them onto the record now. This
+     * keeps env/entrypoint stable across future reconfigures — which use
+     * deleteMissing and would otherwise unset template-provided values that were
+     * never stored.
+     *
+     * Precedence is template < user (user-supplied values win). System and
+     * NVIDIA defaults are intentionally NOT folded in here; they remain
+     * configure-time-only so they are not frozen into the record.
+     *
+     * Persists and returns nothing; mutates this instance.
+     *
+     * @param {object} templateConfig - The cloned template's LXC config
+     * @param {string} [templateConfig.env] - Proxmox NUL-separated `env` string
+     * @param {string} [templateConfig.entrypoint] - Template entrypoint
+     */
+    async persistTemplateDefaults(templateConfig = {}) {
+      const templateEnv = this.constructor.parseLxcEnvString(templateConfig.env);
+      // template < user
+      const mergedEnv = { ...templateEnv, ...this.parseEnvironmentVars() };
+
+      const templateEntrypoint =
+        typeof templateConfig.entrypoint === 'string' && templateConfig.entrypoint.trim()
+          ? templateConfig.entrypoint.trim()
+          : null;
+      const userEntrypoint = this.entrypoint && this.entrypoint.trim() ? this.entrypoint.trim() : null;
+      const mergedEntrypoint = userEntrypoint || templateEntrypoint;
+
+      await this.update({
+        environmentVars: Object.keys(mergedEnv).length > 0 ? JSON.stringify(mergedEnv) : null,
+        entrypoint: mergedEntrypoint
+      });
     }
 
     /**

--- a/create-a-container/models/container.js
+++ b/create-a-container/models/container.js
@@ -21,42 +21,86 @@ module.exports = (sequelize, DataTypes) => {
     }
 
     /**
+     * Normalize a set of environment variables into a safe, flat
+     * { KEY: stringValue } object suitable for building the Proxmox `env`
+     * string. This is the single place that decides what a valid env var is.
+     *
+     * Rules (applied to every source — user input, settings, image defaults):
+     *  - Input that is not a plain object (e.g. an array or null) yields {}.
+     *  - Keys are trimmed. A key is dropped unless it is a non-empty string with
+     *    no whitespace and no `=` or NUL — i.e. it matches a conventional env
+     *    var name. This prevents a key from corrupting the NUL-separated
+     *    `KEY=value` encoding.
+     *  - Values are coerced to strings. Entries whose value is null/undefined or
+     *    a non-primitive (object/array) are dropped rather than stringified to
+     *    something like "[object Object]". Values containing NUL are also
+     *    dropped, since NUL is the pair separator.
+     *
+     * @param {*} input - Candidate env vars, ideally a { key: value } object
+     * @returns {object} Flat object of validated { KEY: stringValue }
+     */
+    static normalizeEnvVars(input) {
+      const out = {};
+      if (!input || typeof input !== 'object' || Array.isArray(input)) return out;
+
+      // Conventional env var name: starts with a letter or underscore, followed
+      // by letters, digits, or underscores. Excludes `=`, NUL, whitespace, etc.
+      const validKey = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+      for (const [rawKey, rawValue] of Object.entries(input)) {
+        const key = typeof rawKey === 'string' ? rawKey.trim() : '';
+        if (!validKey.test(key)) continue;
+
+        // Only primitives (string/number/boolean) become values; skip
+        // null/undefined and objects/arrays.
+        if (rawValue === null || rawValue === undefined) continue;
+        if (typeof rawValue === 'object') continue;
+        const value = String(rawValue);
+        if (value.includes('\0')) continue;
+
+        out[key] = value;
+      }
+      return out;
+    }
+
+    /**
      * Internal helper for buildLxcEnvConfig.
      * Load the admin-defined system default environment variables from the
-     * Settings table, flattened to a { KEY: value } object. Descriptions are
-     * metadata only and are not included. Returns an empty object if the
-     * setting is missing or malformed.
+     * Settings table, flattened to a validated { KEY: value } object.
+     * Descriptions are metadata only and are not included. Returns an empty
+     * object if the setting is missing or malformed.
      * @returns {Promise<object>} Flat object of { KEY: value } system defaults
      */
     static async getSystemDefaultEnvVars() {
       const Setting = this.sequelize.models.Setting;
-      const defaults = {};
+      const raw = {};
       try {
         const entries = await Setting.getDefaultContainerEnvVars();
         for (const entry of entries) {
-          if (entry.key && entry.key.trim()) {
-            defaults[entry.key.trim()] = entry.value || '';
+          // getDefaultContainerEnvVars yields { key, value, description }.
+          if (entry && typeof entry.key === 'string') {
+            raw[entry.key] = entry.value;
           }
         }
       } catch (_) {
         console.warn('Could not load default_container_env_vars from settings, skipping');
       }
-      return defaults;
+      return this.normalizeEnvVars(raw);
     }
 
     /**
      * Internal helper for buildLxcEnvConfig.
-     * Parse the container's user-defined environment variables.
-     * The database record only ever stores the variables the user explicitly
-     * provided — admin/system, image, and NVIDIA defaults are merged in at
-     * configure-time (see buildLxcEnvConfig) and are intentionally NOT persisted.
-     * @returns {object} Flat object of { KEY: value } user-defined env vars
+     * Parse the container's user-defined environment variables into a validated,
+     * flat { KEY: value } object. The database record only ever stores the
+     * variables the user explicitly provided — admin/system, image, and NVIDIA
+     * defaults are merged in at configure-time (see buildLxcEnvConfig) and are
+     * intentionally NOT persisted.
+     * @returns {object} Flat object of validated { KEY: value } user env vars
      */
     parseEnvironmentVars() {
       if (!this.environmentVars) return {};
       try {
-        const parsed = JSON.parse(this.environmentVars);
-        return parsed && typeof parsed === 'object' ? parsed : {};
+        return this.constructor.normalizeEnvVars(JSON.parse(this.environmentVars));
       } catch (err) {
         console.error('Failed to parse environment variables JSON:', err.message);
         return {};
@@ -103,6 +147,8 @@ module.exports = (sequelize, DataTypes) => {
 
       // Merge precedence (lowest to highest):
       //   system defaults < NVIDIA defaults < user-defined values
+      // Every source is already normalized to a safe { KEY: stringValue } map
+      // (see normalizeEnvVars), so the encoding below cannot be corrupted.
       const mergedEnvVars = {
         ...(await this.constructor.getSystemDefaultEnvVars()),
         ...this.nvidiaDefaultEnvVars(),
@@ -112,9 +158,7 @@ module.exports = (sequelize, DataTypes) => {
       // Format as NUL-separated list: KEY1=value1\0KEY2=value2\0KEY3=value3
       const envPairs = [];
       for (const [key, value] of Object.entries(mergedEnvVars)) {
-        if (key && value !== undefined) {
-          envPairs.push(`${key}=${value}`);
-        }
+        envPairs.push(`${key}=${value}`);
       }
       if (envPairs.length > 0) {
         config['env'] = envPairs.join('\0');

--- a/create-a-container/models/container.js
+++ b/create-a-container/models/container.js
@@ -21,6 +21,7 @@ module.exports = (sequelize, DataTypes) => {
     }
 
     /**
+     * Internal helper for buildLxcEnvConfig.
      * Load the admin-defined system default environment variables from the
      * Settings table, flattened to a { KEY: value } object. Descriptions are
      * metadata only and are not included. Returns an empty object if the
@@ -44,6 +45,7 @@ module.exports = (sequelize, DataTypes) => {
     }
 
     /**
+     * Internal helper for buildLxcEnvConfig.
      * Parse the container's user-defined environment variables.
      * The database record only ever stores the variables the user explicitly
      * provided — admin/system, image, and NVIDIA defaults are merged in at
@@ -62,6 +64,7 @@ module.exports = (sequelize, DataTypes) => {
     }
 
     /**
+     * Internal helper for buildLxcEnvConfig.
      * Environment variables implied by this container's configuration that are
      * applied as defaults but never stored in the DB record. Currently this is
      * the NVIDIA GPU passthrough defaults, applied when nvidiaRequested is set.
@@ -76,30 +79,34 @@ module.exports = (sequelize, DataTypes) => {
     }
 
     /**
-     * Build LXC config object for environment variables and entrypoint.
-     * Returns config suitable for Proxmox API updateLxcConfig.
+     * Build the LXC config object for environment variables and entrypoint to
+     * deploy to Proxmox via updateLxcConfig.
      *
-     * Default environment variables are merged in here, at configure-time,
-     * rather than being baked into the container's DB record. User-defined
-     * variables take precedence over any provided defaults.
+     * This is the single entrypoint for determining a container's effective
+     * environment. It owns the full merge of every env-var source, applied here
+     * at configure-time rather than being baked into the container's DB record:
      *
-     * @param {object} [defaults={}] - Flat object of default env vars, e.g. the
-     *   admin-defined system defaults. User-defined values and this container's
-     *   own NVIDIA defaults override these.
-     * @returns {object} Config object with 'env' and 'entrypoint' properties
+     *   admin-defined system defaults < NVIDIA defaults < user-defined values
+     *
+     * (Image-provided defaults are submitted by the UI as user-defined values,
+     * so they arrive via parseEnvironmentVars and need no special handling.)
+     *
+     * Callers should simply `await container.buildLxcEnvConfig()` — no env-var
+     * merging belongs anywhere else.
+     *
+     * @returns {Promise<object>} Config object with 'env' and 'entrypoint'
+     *   properties (and a 'delete' list for any that should be unset)
      */
-    buildLxcEnvConfig(defaults = {}) {
+    async buildLxcEnvConfig() {
       const config = {};
       const deleteList = [];
 
       // Merge precedence (lowest to highest):
-      //   provided defaults (admin-defined system defaults) < NVIDIA defaults
-      //   < user-defined values
-      const userEnvVars = this.parseEnvironmentVars();
+      //   system defaults < NVIDIA defaults < user-defined values
       const mergedEnvVars = {
-        ...(defaults && typeof defaults === 'object' ? defaults : {}),
+        ...(await this.constructor.getSystemDefaultEnvVars()),
         ...this.nvidiaDefaultEnvVars(),
-        ...userEnvVars
+        ...this.parseEnvironmentVars()
       };
 
       // Format as NUL-separated list: KEY1=value1\0KEY2=value2\0KEY3=value3

--- a/create-a-container/models/container.js
+++ b/create-a-container/models/container.js
@@ -135,13 +135,27 @@ module.exports = (sequelize, DataTypes) => {
      * (Image-provided defaults are submitted by the UI as user-defined values,
      * so they arrive via parseEnvironmentVars and need no special handling.)
      *
-     * Callers should simply `await container.buildLxcEnvConfig()` — no env-var
-     * merging belongs anywhere else.
+     * Proxmox's config endpoint is a partial update: keys present in the body are
+     * set, omitted keys are left untouched, and a key is only removed if named in
+     * the special `delete` parameter. That distinction matters here:
      *
+     *  - On create, the container has just been cloned from a template that may
+     *    carry its own `env`/`entrypoint`. We must NOT delete those when the user
+     *    didn't provide a value, or we'd wipe the template's defaults. So the
+     *    default (deleteMissing=false) simply omits anything with no value.
+     *  - On reconfigure, the user may have cleared their last env var or removed a
+     *    custom entrypoint, and that change must take effect — so the caller
+     *    passes deleteMissing=true to emit `delete` for the now-empty fields.
+     *
+     * @param {object} [options]
+     * @param {boolean} [options.deleteMissing=false] - When true, env/entrypoint
+     *   that resolve to empty are added to Proxmox's `delete` list (removing any
+     *   existing value). When false, they are simply omitted, preserving whatever
+     *   the container/template already has.
      * @returns {Promise<object>} Config object with 'env' and 'entrypoint'
-     *   properties (and a 'delete' list for any that should be unset)
+     *   properties (and, when deleteMissing is set, a 'delete' list)
      */
-    async buildLxcEnvConfig() {
+    async buildLxcEnvConfig({ deleteMissing = false } = {}) {
       const config = {};
       const deleteList = [];
 
@@ -162,14 +176,14 @@ module.exports = (sequelize, DataTypes) => {
       }
       if (envPairs.length > 0) {
         config['env'] = envPairs.join('\0');
-      } else {
+      } else if (deleteMissing) {
         deleteList.push('env');
       }
 
       // Set entrypoint command
       if (this.entrypoint && this.entrypoint.trim()) {
         config['entrypoint'] = this.entrypoint.trim();
-      } else {
+      } else if (deleteMissing) {
         deleteList.push('entrypoint');
       }
       

--- a/create-a-container/openapi.v1.yaml
+++ b/create-a-container/openapi.v1.yaml
@@ -107,24 +107,20 @@ components:
     ContainerStatus:
       type: string
       description: >-
-        Live container status, resolved on read from Proxmox presence/run-state,
-        active jobs, and configuration drift.
+        Live container status, resolved on read from Proxmox run-state and the
+        create job.
         running = online in Proxmox;
         offline = exists in Proxmox but stopped;
         creating = no Proxmox VM yet, active create job;
-        restarting = active reconfigure job;
-        failed = no Proxmox VM, last create job failed;
+        failed = no Proxmox VM, create job failed;
         missing = no Proxmox VM, create succeeded or no create job;
-        out-of-sync = exists in Proxmox but config differs from expectation;
         unknown = Proxmox unreachable / no node credentials.
       enum:
         - running
         - offline
         - creating
-        - restarting
         - failed
         - missing
-        - out-of-sync
         - unknown
     Node:
       type: object

--- a/create-a-container/openapi.v1.yaml
+++ b/create-a-container/openapi.v1.yaml
@@ -360,26 +360,6 @@ paths:
     get: { tags: [Containers], responses: { '200': { description: Container } } }
     put: { tags: [Containers], responses: { '200': { description: Updated, optional restart job } } }
     delete: { tags: [Containers], responses: { '200': { description: Deleted, with DNS cleanup warnings } } }
-  /sites/{siteId}/containers/{id}/status:
-    get:
-      tags: [Containers]
-      summary: Live container status (computed from Proxmox + jobs + config drift)
-      parameters:
-        - { in: path, name: siteId, required: true, schema: { type: integer } }
-        - { in: path, name: id, required: true, schema: { type: integer } }
-      responses:
-        '200':
-          description: Resolved container status
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      status: { $ref: '#/components/schemas/ContainerStatus' }
-        '404': { description: Container not found }
 
   /sites/{siteId}/nodes:
     parameters: [{ in: path, name: siteId, required: true, schema: { type: integer } }]

--- a/create-a-container/openapi.v1.yaml
+++ b/create-a-container/openapi.v1.yaml
@@ -89,7 +89,7 @@ components:
         id: { type: integer }
         hostname: { type: string }
         containerId: { type: integer, nullable: true }
-        status: { type: string }
+        status: { $ref: '#/components/schemas/ContainerStatus' }
         template: { type: string }
         ipv4Address: { type: string, nullable: true }
         macAddress: { type: string, nullable: true }
@@ -104,6 +104,28 @@ components:
         services:
           type: array
           items: { type: object }
+    ContainerStatus:
+      type: string
+      description: >-
+        Live container status, resolved on read from Proxmox presence/run-state,
+        active jobs, and configuration drift.
+        running = online in Proxmox;
+        offline = exists in Proxmox but stopped;
+        creating = no Proxmox VM yet, active create job;
+        restarting = active reconfigure job;
+        failed = no Proxmox VM, last create job failed;
+        missing = no Proxmox VM, create succeeded or no create job;
+        out-of-sync = exists in Proxmox but config differs from expectation;
+        unknown = Proxmox unreachable / no node credentials.
+      enum:
+        - running
+        - offline
+        - creating
+        - restarting
+        - failed
+        - missing
+        - out-of-sync
+        - unknown
     Node:
       type: object
       properties:
@@ -338,6 +360,26 @@ paths:
     get: { tags: [Containers], responses: { '200': { description: Container } } }
     put: { tags: [Containers], responses: { '200': { description: Updated, optional restart job } } }
     delete: { tags: [Containers], responses: { '200': { description: Deleted, with DNS cleanup warnings } } }
+  /sites/{siteId}/containers/{id}/status:
+    get:
+      tags: [Containers]
+      summary: Live container status (computed from Proxmox + jobs + config drift)
+      parameters:
+        - { in: path, name: siteId, required: true, schema: { type: integer } }
+        - { in: path, name: id, required: true, schema: { type: integer } }
+      responses:
+        '200':
+          description: Resolved container status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      status: { $ref: '#/components/schemas/ContainerStatus' }
+        '404': { description: Container not found }
 
   /sites/{siteId}/nodes:
     parameters: [{ in: path, name: siteId, required: true, schema: { type: integer } }]

--- a/create-a-container/routers/api/v1/containers.js
+++ b/create-a-container/routers/api/v1/containers.js
@@ -243,6 +243,10 @@ router.post(
       if (!hostname || !hostname.trim()) throw new ApiError(400, 'invalid_request', 'hostname is required');
 
       const wantsNvidia = !!nvidiaRequested;
+      // Only the user-defined env vars are persisted on the container record.
+      // NVIDIA defaults (for GPU passthrough) and admin-defined system defaults
+      // are merged in at configure-time by the create/reconfigure jobs, so they
+      // are intentionally not stored here.
       let envVarsJson = null;
       if (Array.isArray(environmentVars) && environmentVars.length > 0) {
         const envObj = {};
@@ -250,12 +254,6 @@ router.post(
           if (e?.key && e.key.trim()) envObj[e.key.trim()] = e.value || '';
         }
         if (Object.keys(envObj).length > 0) envVarsJson = JSON.stringify(envObj);
-      }
-      if (wantsNvidia) {
-        const obj = envVarsJson ? JSON.parse(envVarsJson) : {};
-        if (!obj.NVIDIA_VISIBLE_DEVICES) obj.NVIDIA_VISIBLE_DEVICES = 'all';
-        if (!obj.NVIDIA_DRIVER_CAPABILITIES) obj.NVIDIA_DRIVER_CAPABILITIES = 'utility compute';
-        envVarsJson = JSON.stringify(obj);
       }
 
       const imageRef = template === 'custom' ? customTemplate?.trim() : template;

--- a/create-a-container/routers/api/v1/containers.js
+++ b/create-a-container/routers/api/v1/containers.js
@@ -27,6 +27,25 @@ const router = express.Router({ mergeParams: true });
 
 router.use(apiAuth);
 
+/**
+ * Convert the `environmentVars` request payload (an array of { key, value }
+ * objects) into the JSON string stored on the container record, or null when
+ * there are no valid vars. Keys/values are validated and normalized via
+ * Container.normalizeEnvVars so only safe env var names are persisted (keys
+ * containing `=`/NUL or non-primitive values are dropped at ingest time).
+ * @param {Array<{key: string, value: *}>} environmentVars
+ * @returns {string|null}
+ */
+function serializeUserEnvVars(environmentVars) {
+  if (!Array.isArray(environmentVars)) return null;
+  const flat = {};
+  for (const e of environmentVars) {
+    if (e && typeof e.key === 'string') flat[e.key] = e.value;
+  }
+  const normalized = Container.normalizeEnvVars(flat);
+  return Object.keys(normalized).length > 0 ? JSON.stringify(normalized) : null;
+}
+
 function normalizeDockerRef(ref) {
   if (ref.startsWith('http://') || ref.startsWith('https://') || ref.startsWith('git@')) return ref;
   let tag = 'latest';
@@ -243,14 +262,9 @@ router.post(
       if (!hostname || !hostname.trim()) throw new ApiError(400, 'invalid_request', 'hostname is required');
 
       const wantsNvidia = !!nvidiaRequested;
-      let envVarsJson = null;
-      if (Array.isArray(environmentVars) && environmentVars.length > 0) {
-        const envObj = {};
-        for (const e of environmentVars) {
-          if (e?.key && e.key.trim()) envObj[e.key.trim()] = e.value || '';
-        }
-        if (Object.keys(envObj).length > 0) envVarsJson = JSON.stringify(envObj);
-      }
+      // Only the user-defined env vars are persisted on the container record;
+      // NVIDIA and admin-defined system defaults are merged in at configure-time.
+      const envVarsJson = serializeUserEnvVars(environmentVars);
 
       const imageRef = template === 'custom' ? customTemplate?.trim() : template;
       if (!imageRef) throw new ApiError(400, 'invalid_request', 'template is required');
@@ -383,11 +397,7 @@ router.put(
 
     let envVarsJson = container.environmentVars;
     if (!isRestartOnly && Array.isArray(environmentVars)) {
-      const obj = {};
-      for (const e of environmentVars) {
-        if (e?.key) obj[e.key.trim()] = e.value || '';
-      }
-      envVarsJson = Object.keys(obj).length > 0 ? JSON.stringify(obj) : null;
+      envVarsJson = serializeUserEnvVars(environmentVars);
     } else if (!isRestartOnly && !environmentVars) {
       envVarsJson = null;
     }

--- a/create-a-container/routers/api/v1/containers.js
+++ b/create-a-container/routers/api/v1/containers.js
@@ -211,10 +211,12 @@ router.get(
         },
         // Full node record (incl. credentials) is required to query live Proxmox status.
         { association: 'node' },
+        // Eager-load the create job so status resolution needs no per-container query.
+        { association: 'creationJob' },
       ],
     });
     // Resolve live statuses for the whole page in one pass: one Proxmox snapshot
-    // per node (shared), rather than N independent round-trips from the browser.
+    // per node (shared), and no per-container DB queries (create job is loaded above).
     const statuses = await computeContainerStatuses(rows, Job);
     return ok(
       res,

--- a/create-a-container/routers/api/v1/containers.js
+++ b/create-a-container/routers/api/v1/containers.js
@@ -223,30 +223,6 @@ router.get(
   }),
 );
 
-// GET /containers/:id/status — live status for a single container
-router.get(
-  '/:id/status',
-  asyncHandler(async (req, res) => {
-    const site = await loadSite(req);
-    const containerId = parseInt(req.params.id, 10);
-    if (!Number.isInteger(containerId) || containerId <= 0) {
-      throw new ApiError(404, 'not_found', 'Container not found');
-    }
-    const c = await Container.findOne({
-      where: { id: containerId, username: req.session.user },
-      include: [
-        { association: 'node' },
-        { association: 'creationJob' },
-      ],
-    });
-    if (!c || !c.node || c.node.siteId !== site.id) {
-      throw new ApiError(404, 'not_found', 'Container not found');
-    }
-    const status = await computeContainerStatus({ container: c, Job });
-    return ok(res, { status });
-  }),
-);
-
 // GET /containers/:id
 router.get(
   '/:id',

--- a/create-a-container/routers/api/v1/containers.js
+++ b/create-a-container/routers/api/v1/containers.js
@@ -21,6 +21,11 @@ const {
 const { parseDockerRef, getImageConfig, extractImageMetadata } = require('../../../utils/docker-registry');
 const { manageDnsRecords } = require('../../../utils/cloudflare-dns');
 const { deleteVirtualMachine, withNetbox } = require('../../../utils/netbox');
+const {
+  computeContainerStatus,
+  computeContainerStatuses,
+  STATUS,
+} = require('../../../utils/container-status');
 const { apiAuth, asyncHandler, ok, created, ApiError } = require('../../../middlewares/api');
 
 const router = express.Router({ mergeParams: true });
@@ -86,7 +91,7 @@ async function loadSite(req) {
   return site;
 }
 
-function serializeContainer(c, site) {
+function serializeContainer(c, site, status) {
   const services = c.services || [];
   const ssh = services.find(
     (s) =>
@@ -110,7 +115,9 @@ function serializeContainer(c, site) {
     hostname: c.hostname,
     ipv4Address: c.ipv4Address,
     macAddress: c.macAddress,
-    status: c.status,
+    // Live status computed from Proxmox + jobs + config (see utils/container-status).
+    // Kept on every container payload so existing consumers remain non-breaking.
+    status: status || STATUS.UNKNOWN,
     template: c.template,
     creationJobId: c.creationJobId,
     entrypoint: c.entrypoint,
@@ -202,10 +209,41 @@ router.get(
             { association: 'dnsService' },
           ],
         },
-        { association: 'node', attributes: ['id', 'name', 'apiUrl'] },
+        // Full node record (incl. credentials) is required to query live Proxmox status.
+        { association: 'node' },
       ],
     });
-    return ok(res, rows.map((c) => serializeContainer(c, site)));
+    // Resolve live statuses for the whole page in one pass: one Proxmox snapshot
+    // per node (shared), rather than N independent round-trips from the browser.
+    const statuses = await computeContainerStatuses(rows, Job);
+    return ok(
+      res,
+      rows.map((c) => serializeContainer(c, site, statuses.get(c.id))),
+    );
+  }),
+);
+
+// GET /containers/:id/status — live status for a single container
+router.get(
+  '/:id/status',
+  asyncHandler(async (req, res) => {
+    const site = await loadSite(req);
+    const containerId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(containerId) || containerId <= 0) {
+      throw new ApiError(404, 'not_found', 'Container not found');
+    }
+    const c = await Container.findOne({
+      where: { id: containerId, username: req.session.user },
+      include: [
+        { association: 'node' },
+        { association: 'creationJob' },
+      ],
+    });
+    if (!c || !c.node || c.node.siteId !== site.id) {
+      throw new ApiError(404, 'not_found', 'Container not found');
+    }
+    const status = await computeContainerStatus({ container: c, Job });
+    return ok(res, { status });
   }),
 );
 
@@ -233,12 +271,14 @@ router.get(
           ],
         },
         { association: 'node' },
+        { association: 'creationJob' },
       ],
     });
     if (!c || !c.node || c.node.siteId !== site.id) {
       throw new ApiError(404, 'not_found', 'Container not found');
     }
-    return ok(res, serializeContainer(c, site));
+    const status = await computeContainerStatus({ container: c, Job });
+    return ok(res, serializeContainer(c, site, status));
   }),
 );
 
@@ -296,7 +336,6 @@ router.post(
         {
           hostname,
           username: req.session.user,
-          status: 'pending',
           template: templateName,
           nodeId: node.id,
           siteId: site.id,
@@ -371,7 +410,9 @@ router.post(
         containerId: container.id,
         jobId: job.id,
         hostname: container.hostname,
-        status: 'pending',
+        // A create job was just enqueued and there is no Proxmox VMID yet, so the
+        // live status resolver would report 'creating' — return it directly.
+        status: STATUS.CREATING,
       });
     } catch (err) {
       await t.rollback();
@@ -414,16 +455,15 @@ router.put(
     const dnsWarnings = [];
     await sequelize.transaction(async (t) => {
       if (envChanged || entrypointChanged) {
+        // Persist the new desired config only. The "restarting" state is no
+        // longer stored — it is derived from the active reconfigure job below.
         await container.update(
           {
             environmentVars: envVarsJson,
             entrypoint: newEntrypoint,
-            status: needsRestart && container.containerId ? 'restarting' : container.status,
           },
           { transaction: t },
         );
-      } else if (forceRestart && container.containerId) {
-        await container.update({ status: 'restarting' }, { transaction: t });
       }
       if (needsRestart && container.containerId) {
         restartJob = await Job.create(

--- a/create-a-container/routers/api/v1/containers.js
+++ b/create-a-container/routers/api/v1/containers.js
@@ -243,10 +243,6 @@ router.post(
       if (!hostname || !hostname.trim()) throw new ApiError(400, 'invalid_request', 'hostname is required');
 
       const wantsNvidia = !!nvidiaRequested;
-      // Only the user-defined env vars are persisted on the container record.
-      // NVIDIA defaults (for GPU passthrough) and admin-defined system defaults
-      // are merged in at configure-time by the create/reconfigure jobs, so they
-      // are intentionally not stored here.
       let envVarsJson = null;
       if (Array.isArray(environmentVars) && environmentVars.length > 0) {
         const envObj = {};

--- a/create-a-container/routers/api/v1/containers.js
+++ b/create-a-container/routers/api/v1/containers.js
@@ -431,8 +431,6 @@ router.put(
     const dnsWarnings = [];
     await sequelize.transaction(async (t) => {
       if (envChanged || entrypointChanged) {
-        // Persist the new desired config only. The "restarting" state is no
-        // longer stored — it is derived from the active reconfigure job below.
         await container.update(
           {
             environmentVars: envVarsJson,

--- a/create-a-container/routers/api/v1/nodes.js
+++ b/create-a-container/routers/api/v1/nodes.js
@@ -247,7 +247,6 @@ router.post(
             containerId: c.vmid,
             macAddress,
             ipv4Address,
-            status: 'running',
           };
         }),
       );

--- a/create-a-container/routers/api/v1/resource-requests.js
+++ b/create-a-container/routers/api/v1/resource-requests.js
@@ -217,12 +217,15 @@ router.put(
 );
 
 /**
- * Apply a resource change to existing running containers matching the identity.
+ * Apply a resource change to existing provisioned containers matching the identity.
  * This creates a reconfigure job for each matching container.
  */
 async function applyResourceToExistingContainers(siteId, hostname, username, resourceType, value) {
   const containers = await Container.findAll({
-    where: { siteId, hostname, username, status: 'running' },
+    // Only containers that exist in Proxmox (have a VMID) can be reconfigured.
+    // The status column was removed; reconfigure-container.js exits early without
+    // a containerId, so this is the correct provisioned predicate.
+    where: { siteId, hostname, username, containerId: { [Op.ne]: null } },
   });
 
   if (containers.length === 0) return;

--- a/create-a-container/routers/templates.js
+++ b/create-a-container/routers/templates.js
@@ -1,8 +1,18 @@
 const express = require('express');
+const { Op } = require('sequelize');
 const { Site, Node, Container, Service, HTTPService, TransportService, ExternalDomain } = require('../models');
 const { requireLocalhostOrAdmin } = require('../middlewares');
 
 const router = express.Router();
+
+// A container is eligible for routing/DNS config once it has been provisioned,
+// i.e. it has a Proxmox VMID and an assigned IPv4 address. The old code filtered
+// on the (now-removed) static status column; presence of an IP/VMID is the stable,
+// Proxmox-independent proxy for "this container is live enough to route to".
+const PROVISIONED_CONTAINER_WHERE = {
+  containerId: { [Op.ne]: null },
+  ipv4Address: { [Op.ne]: null },
+};
 
 async function loadDnsmasqSite(siteId) {
   return Site.findByPk(siteId, {
@@ -12,7 +22,7 @@ async function loadDnsmasqSite(siteId) {
       include: [{
         model: Container,
         as: 'containers',
-        where: { status: 'running' },
+        where: PROVISIONED_CONTAINER_WHERE,
         required: false,
         attributes: ['macAddress', 'ipv4Address', 'hostname'],
       }],
@@ -40,7 +50,7 @@ router.get('/sites/:siteId/nginx', requireLocalhostOrAdmin, async (req, res) => 
       include: [{
         model: Container,
         as: 'containers',
-        where: { status: 'running' },
+        where: PROVISIONED_CONTAINER_WHERE,
         required: false,
         include: [{
           model: Service,

--- a/create-a-container/routers/templates.js
+++ b/create-a-container/routers/templates.js
@@ -5,13 +5,6 @@ const { requireLocalhostOrAdmin } = require('../middlewares');
 
 const router = express.Router();
 
-// A container is routable once it has an assigned IPv4 address. The old code
-// filtered on the (now-removed) static status column; presence of an IP is the
-// stable, Proxmox-independent requirement for "this container can be routed to".
-const ROUTABLE_CONTAINER_WHERE = {
-  ipv4Address: { [Op.ne]: null },
-};
-
 async function loadDnsmasqSite(siteId) {
   return Site.findByPk(siteId, {
     include: [{
@@ -20,7 +13,8 @@ async function loadDnsmasqSite(siteId) {
       include: [{
         model: Container,
         as: 'containers',
-        where: ROUTABLE_CONTAINER_WHERE,
+        // Only containers with an assigned IPv4 are routable.
+        where: { ipv4Address: { [Op.ne]: null } },
         required: false,
         attributes: ['macAddress', 'ipv4Address', 'hostname'],
       }],
@@ -48,7 +42,8 @@ router.get('/sites/:siteId/nginx', requireLocalhostOrAdmin, async (req, res) => 
       include: [{
         model: Container,
         as: 'containers',
-        where: ROUTABLE_CONTAINER_WHERE,
+        // Only containers with an assigned IPv4 are routable.
+        where: { ipv4Address: { [Op.ne]: null } },
         required: false,
         include: [{
           model: Service,

--- a/create-a-container/routers/templates.js
+++ b/create-a-container/routers/templates.js
@@ -5,12 +5,10 @@ const { requireLocalhostOrAdmin } = require('../middlewares');
 
 const router = express.Router();
 
-// A container is eligible for routing/DNS config once it has been provisioned,
-// i.e. it has a Proxmox VMID and an assigned IPv4 address. The old code filtered
-// on the (now-removed) static status column; presence of an IP/VMID is the stable,
-// Proxmox-independent proxy for "this container is live enough to route to".
-const PROVISIONED_CONTAINER_WHERE = {
-  containerId: { [Op.ne]: null },
+// A container is routable once it has an assigned IPv4 address. The old code
+// filtered on the (now-removed) static status column; presence of an IP is the
+// stable, Proxmox-independent requirement for "this container can be routed to".
+const ROUTABLE_CONTAINER_WHERE = {
   ipv4Address: { [Op.ne]: null },
 };
 
@@ -22,7 +20,7 @@ async function loadDnsmasqSite(siteId) {
       include: [{
         model: Container,
         as: 'containers',
-        where: PROVISIONED_CONTAINER_WHERE,
+        where: ROUTABLE_CONTAINER_WHERE,
         required: false,
         attributes: ['macAddress', 'ipv4Address', 'hostname'],
       }],
@@ -50,7 +48,7 @@ router.get('/sites/:siteId/nginx', requireLocalhostOrAdmin, async (req, res) => 
       include: [{
         model: Container,
         as: 'containers',
-        where: PROVISIONED_CONTAINER_WHERE,
+        where: ROUTABLE_CONTAINER_WHERE,
         required: false,
         include: [{
           model: Service,

--- a/create-a-container/routers/templates.js
+++ b/create-a-container/routers/templates.js
@@ -13,7 +13,6 @@ async function loadDnsmasqSite(siteId) {
       include: [{
         model: Container,
         as: 'containers',
-        // Only containers with an assigned IPv4 are routable.
         where: { ipv4Address: { [Op.ne]: null } },
         required: false,
         attributes: ['macAddress', 'ipv4Address', 'hostname'],
@@ -42,7 +41,6 @@ router.get('/sites/:siteId/nginx', requireLocalhostOrAdmin, async (req, res) => 
       include: [{
         model: Container,
         as: 'containers',
-        // Only containers with an assigned IPv4 are routable.
         where: { ipv4Address: { [Op.ne]: null } },
         required: false,
         include: [{

--- a/create-a-container/utils/container-status.js
+++ b/create-a-container/utils/container-status.js
@@ -43,11 +43,28 @@ const STATUS_VALUES = Object.freeze(Object.values(STATUS));
 // container router / resource-requests, so we match them exactly here.
 //   create:      node bin/create-container.js --container-id=<id>
 //   reconfigure: node bin/reconfigure-container.js --container-id=<id>[ --<resource>=<value>...]
+const CREATE_PREFIX = 'node bin/create-container.js --container-id=';
+const RECONFIGURE_PREFIX = 'node bin/reconfigure-container.js --container-id=';
+
 function createCommand(id) {
-  return `node bin/create-container.js --container-id=${id}`;
+  return `${CREATE_PREFIX}${id}`;
 }
 function reconfigureCommand(id) {
-  return `node bin/reconfigure-container.js --container-id=${id}`;
+  return `${RECONFIGURE_PREFIX}${id}`;
+}
+
+// Extract the container id from a create/reconfigure job command, or null if the
+// command isn't one of ours. The id is the run of digits immediately after a
+// known prefix, terminated by end-of-string or a space (so 12 != 123).
+const COMMAND_CONTAINER_ID_RE = new RegExp(
+  `^node bin/(?:create|reconfigure)-container\\.js --container-id=(\\d+)(?: |$)`,
+);
+function containerIdFromCommand(command) {
+  const m = COMMAND_CONTAINER_ID_RE.exec(command || '');
+  return m ? parseInt(m[1], 10) : null;
+}
+function isCreateCommand(command) {
+  return typeof command === 'string' && command.startsWith(CREATE_PREFIX);
 }
 
 const ACTIVE_JOB_STATUSES = ['pending', 'running'];
@@ -92,6 +109,60 @@ async function findLatestReconfigureJob(container, Job) {
     },
     order: [['createdAt', 'DESC']],
   });
+}
+
+/**
+ * Prefetch the latest create and reconfigure job for many containers in a single
+ * DB query, so resolving N containers' statuses is O(1) queries instead of O(N).
+ *
+ * Jobs are matched by their deterministic command strings (exact create command,
+ * and reconfigure command optionally followed by resource flags) for the given
+ * container ids, fetched newest-first, then bucketed per container keeping the
+ * first (latest) of each kind.
+ *
+ * @param {Array<object>} containers - Container instances.
+ * @param {object} Job - Job model.
+ * @returns {Promise<Map<number, { createJob: object|null, reconfigureJob: object|null }>>}
+ */
+async function prefetchLatestJobs(containers, Job) {
+  const byContainer = new Map();
+  const ids = [];
+  for (const c of containers) {
+    byContainer.set(c.id, { createJob: null, reconfigureJob: null });
+    ids.push(c.id);
+  }
+  if (ids.length === 0) return byContainer;
+
+  // One query for all relevant jobs, with a bounded number of WHERE clauses
+  // (independent of N):
+  //   - exact create commands for these ids
+  //   - exact (arg-less) reconfigure commands for these ids
+  //   - any reconfigure command carrying trailing flags (prefix LIKE)
+  // The prefix LIKE may match reconfigure jobs for containers not on this page;
+  // those are discarded during bucketing below (byContainer lookup).
+  const orClauses = [
+    { command: { [Op.in]: ids.map(createCommand) } },
+    { command: { [Op.in]: ids.map(reconfigureCommand) } },
+    { command: { [Op.like]: `${RECONFIGURE_PREFIX}%` } },
+  ];
+  const jobs = await Job.findAll({
+    where: { [Op.or]: orClauses },
+    order: [['createdAt', 'DESC']],
+  });
+
+  // Bucket newest-first; the first job seen for a (container, kind) is the latest.
+  for (const job of jobs) {
+    const id = containerIdFromCommand(job.command);
+    if (id == null) continue;
+    const entry = byContainer.get(id);
+    if (!entry) continue;
+    if (isCreateCommand(job.command)) {
+      if (!entry.createJob) entry.createJob = job;
+    } else if (!entry.reconfigureJob) {
+      entry.reconfigureJob = job;
+    }
+  }
+  return byContainer;
 }
 
 function isActiveJob(job) {
@@ -219,9 +290,13 @@ function decideStatus(facts) {
  * @param {{ data: Array<object>, ok: boolean }} [params.snapshot] - Optional
  *   pre-fetched clusterResources('lxc') snapshot for the node. `ok` indicates the
  *   query succeeded; `data` is the resource list (used for batching the index).
+ * @param {{ createJob: object|null, reconfigureJob: object|null }} [params.jobs] -
+ *   Optional prefetched latest create/reconfigure jobs for this container (see
+ *   prefetchLatestJobs). When provided, the per-container job DB lookups are
+ *   skipped, making batch resolution O(1) queries instead of O(N).
  * @returns {Promise<string>} One of the STATUS values.
  */
-async function computeContainerStatus({ container, Job, api, snapshot }) {
+async function computeContainerStatus({ container, Job, api, snapshot, jobs }) {
   const node = container.node;
   const hasCreds = nodeHasCreds(node);
   const hasVmid = container.containerId != null;
@@ -261,7 +336,10 @@ async function computeContainerStatus({ container, Job, api, snapshot }) {
   }
 
   // --- Jobs ---
-  const reconfigureJob = await findLatestReconfigureJob(container, Job);
+  // Use prefetched jobs when supplied (batch path); otherwise query per container.
+  const reconfigureJob = jobs
+    ? jobs.reconfigureJob
+    : await findLatestReconfigureJob(container, Job);
   const restarting = isActiveJob(reconfigureJob);
 
   // Drift detection (only meaningful if it exists and isn't already restarting).
@@ -282,7 +360,7 @@ async function computeContainerStatus({ container, Job, api, snapshot }) {
   let createFailed = false;
   let hasCreateJob = false;
   if (!inProxmox) {
-    const createJob = await findLatestCreateJob(container, Job);
+    const createJob = jobs ? jobs.createJob : await findLatestCreateJob(container, Job);
     hasCreateJob = !!createJob;
     creating = isActiveJob(createJob);
     createFailed = !!createJob && createJob.status === 'failure';
@@ -304,10 +382,12 @@ async function computeContainerStatus({ container, Job, api, snapshot }) {
 /**
  * Compute live statuses for many containers efficiently.
  *
- * Groups containers by node so each node's Proxmox `clusterResources('lxc')`
- * snapshot is fetched exactly once and a single authenticated client is reused
- * for that node's containers (including per-container config reads). This keeps
- * total end-user latency low for the list page versus N independent calls.
+ * Two batching strategies keep this fast for the list page:
+ *   - Jobs: a single DB query fetches the latest create/reconfigure job for every
+ *     container up front (O(1) queries instead of O(N)).
+ *   - Proxmox: containers are grouped by node so each node's
+ *     `clusterResources('lxc')` snapshot is fetched exactly once and a single
+ *     authenticated client is reused for that node's containers.
  *
  * @param {Array<object>} containers - Container instances (each with `node`).
  * @param {object} Job - Job model.
@@ -315,6 +395,9 @@ async function computeContainerStatus({ container, Job, api, snapshot }) {
  */
 async function computeContainerStatuses(containers, Job) {
   const result = new Map();
+
+  // One query for everyone's latest create/reconfigure jobs.
+  const jobsByContainer = await prefetchLatestJobs(containers, Job);
 
   // Group by node id (containers without a node still get resolved, just without
   // any Proxmox facts).
@@ -344,8 +427,12 @@ async function computeContainerStatuses(containers, Job) {
       // Resolve each container in the group sequentially per node (shares the
       // single authenticated client); different nodes run in parallel.
       for (const container of group) {
+        const jobs = jobsByContainer.get(container.id) || {
+          createJob: null,
+          reconfigureJob: null,
+        };
         // eslint-disable-next-line no-await-in-loop
-        const status = await computeContainerStatus({ container, Job, api, snapshot });
+        const status = await computeContainerStatus({ container, Job, api, snapshot, jobs });
         result.set(container.id, status);
       }
     }),
@@ -366,4 +453,6 @@ module.exports = {
   findInSnapshot,
   findLatestCreateJob,
   findLatestReconfigureJob,
+  prefetchLatestJobs,
+  containerIdFromCommand,
 };

--- a/create-a-container/utils/container-status.js
+++ b/create-a-container/utils/container-status.js
@@ -50,6 +50,38 @@ function nodeHasCreds(node) {
 }
 
 /**
+ * Escape a string for safe use inside a RegExp.
+ * @param {string|number} s
+ * @returns {string}
+ */
+function escapeRegExp(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Find the most recent job for a container whose command contains
+ * `<cmdFragment> --container-id=<id>` as a *whole* argument.
+ *
+ * A plain SQL LIKE on `--container-id=<id>` would also match longer ids
+ * (id 12 matches `--container-id=123`), so we use LIKE only to narrow at the DB
+ * level (ordered most-recent first) and then confirm each candidate in JS with a
+ * regex requiring the id to be terminated by a space or end-of-string.
+ *
+ * @param {object} Job - Job model
+ * @param {string} cmdFragment - e.g. CREATE_CMD or RECONFIGURE_CMD
+ * @param {number} id - Container database id
+ * @returns {Promise<object|null>}
+ */
+async function findLatestJobForContainer(Job, cmdFragment, id) {
+  const candidates = await Job.findAll({
+    where: { command: { [Op.like]: `%${cmdFragment} --container-id=${id}%` } },
+    order: [['createdAt', 'DESC']],
+  });
+  const whole = new RegExp(`${escapeRegExp(cmdFragment)} --container-id=${escapeRegExp(id)}(?:\\s|$)`);
+  return candidates.find((job) => whole.test(job.command)) || null;
+}
+
+/**
  * Find the most recent create job for a container.
  * Prefers the explicit creationJobId FK; falls back to a command-string match.
  * @param {object} container - Container instance (with optional creationJob assoc)
@@ -61,10 +93,7 @@ async function findLatestCreateJob(container, Job) {
   if (container.creationJobId) {
     return Job.findByPk(container.creationJobId);
   }
-  return Job.findOne({
-    where: { command: { [Op.like]: `%${CREATE_CMD} --container-id=${container.id}%` } },
-    order: [['createdAt', 'DESC']],
-  });
+  return findLatestJobForContainer(Job, CREATE_CMD, container.id);
 }
 
 /**
@@ -74,10 +103,7 @@ async function findLatestCreateJob(container, Job) {
  * @returns {Promise<object|null>}
  */
 async function findLatestReconfigureJob(container, Job) {
-  return Job.findOne({
-    where: { command: { [Op.like]: `%${RECONFIGURE_CMD} --container-id=${container.id}%` } },
-    order: [['createdAt', 'DESC']],
-  });
+  return findLatestJobForContainer(Job, RECONFIGURE_CMD, container.id);
 }
 
 function isActiveJob(job) {

--- a/create-a-container/utils/container-status.js
+++ b/create-a-container/utils/container-status.js
@@ -5,67 +5,39 @@
  * was only mutated by the create/reconfigure job scripts. That value drifts out
  * of reality whenever something changes a container directly in Proxmox (or when
  * a job dies without updating the row). This module computes the real status on
- * demand by combining three sources of truth:
+ * demand by combining two sources of truth:
  *
- *   1. Proxmox  — does the LXC exist, and is it running or stopped?
- *   2. Jobs     — is there an active create/restart job, or did the last create
- *                 job fail?
- *   3. Config   — does the live LXC config match what the API server expects?
+ *   1. Proxmox    — does the LXC exist, and is it running or stopped? This comes
+ *                   from a single per-node `clusterResources('lxc')` snapshot.
+ *   2. Create job — for containers not yet in Proxmox: is the create job still
+ *                   active, did it fail, or is it gone? The create job is linked
+ *                   to the container by the `creationJobId` foreign key, so this
+ *                   is a cheap primary-key lookup (or free when eager-loaded).
  *
- * Resolved statuses (a strict superset of the old running/offline values):
- *   running      — exists in Proxmox and is online
- *   offline      — exists in Proxmox but is stopped
- *   restarting   — has an active (pending/running) reconfigure job
- *   creating     — not in Proxmox, but has an active (pending/running) create job
- *   failed       — not in Proxmox, last create job returned failure
- *   missing      — not in Proxmox, create job succeeded or no create job found
- *   out-of-sync  — exists in Proxmox but its config doesn't match expectation
- *   unknown      — Proxmox could not be reached / node has no API credentials
+ * Resolved statuses:
+ *   running   — exists in Proxmox and is online
+ *   offline   — exists in Proxmox but is stopped
+ *   creating  — not in Proxmox, but has an active (pending/running) create job
+ *   failed    — not in Proxmox, create job returned failure
+ *   missing   — not in Proxmox, create job succeeded or no create job found
+ *   unknown   — Proxmox could not be reached / node has no API credentials
+ *
+ * Note: there is intentionally no per-container Proxmox config read here. Proxmox
+ * has no bulk config endpoint, so config-drift detection would be O(N) network
+ * round-trips for the list page; it was dropped in favour of keeping status
+ * resolution cheap (one Proxmox call per node, zero per container).
  */
-
-const { Op } = require('sequelize');
 
 const STATUS = Object.freeze({
   RUNNING: 'running',
   OFFLINE: 'offline',
   CREATING: 'creating',
-  RESTARTING: 'restarting',
   FAILED: 'failed',
   MISSING: 'missing',
-  OUT_OF_SYNC: 'out-of-sync',
   UNKNOWN: 'unknown',
 });
 
 const STATUS_VALUES = Object.freeze(Object.values(STATUS));
-
-// Job command builders. Jobs are distinguished solely by their `command` string
-// (no type column), and the commands are constructed deterministically by the
-// container router / resource-requests, so we match them exactly here.
-//   create:      node bin/create-container.js --container-id=<id>
-//   reconfigure: node bin/reconfigure-container.js --container-id=<id>[ --<resource>=<value>...]
-const CREATE_PREFIX = 'node bin/create-container.js --container-id=';
-const RECONFIGURE_PREFIX = 'node bin/reconfigure-container.js --container-id=';
-
-function createCommand(id) {
-  return `${CREATE_PREFIX}${id}`;
-}
-function reconfigureCommand(id) {
-  return `${RECONFIGURE_PREFIX}${id}`;
-}
-
-// Extract the container id from a create/reconfigure job command, or null if the
-// command isn't one of ours. The id is the run of digits immediately after a
-// known prefix, terminated by end-of-string or a space (so 12 != 123).
-const COMMAND_CONTAINER_ID_RE = new RegExp(
-  `^node bin/(?:create|reconfigure)-container\\.js --container-id=(\\d+)(?: |$)`,
-);
-function containerIdFromCommand(command) {
-  const m = COMMAND_CONTAINER_ID_RE.exec(command || '');
-  return m ? parseInt(m[1], 10) : null;
-}
-function isCreateCommand(command) {
-  return typeof command === 'string' && command.startsWith(CREATE_PREFIX);
-}
 
 const ACTIVE_JOB_STATUSES = ['pending', 'running'];
 
@@ -74,165 +46,22 @@ function nodeHasCreds(node) {
 }
 
 /**
- * Find the most recent create job for a container.
- * Prefers the explicit creationJobId FK; falls back to an exact command match.
- * Create commands never carry trailing arguments, so the match is exact.
- * @param {object} container - Container instance (with optional creationJob assoc)
+ * Resolve the create job for a container via its `creationJobId` foreign key.
+ * Prefers an already-loaded `creationJob` association (zero queries); otherwise
+ * does a single primary-key lookup. Returns null if the container has no linked
+ * create job.
+ * @param {object} container - Container instance (ideally with creationJob assoc)
  * @param {object} Job - Job model
  * @returns {Promise<object|null>}
  */
-async function findLatestCreateJob(container, Job) {
+async function findCreateJob(container, Job) {
   if (container.creationJob) return container.creationJob;
-  if (container.creationJobId) {
-    return Job.findByPk(container.creationJobId);
-  }
-  return Job.findOne({
-    where: { command: createCommand(container.id) },
-    order: [['createdAt', 'DESC']],
-  });
-}
-
-/**
- * Find the most recent reconfigure (restart) job for a container, if any.
- * A reconfigure command is either exactly `<cmd> --container-id=<id>` or that
- * followed by ` --<resource>=<value>` flags, so we match the exact form OR the
- * exact form followed by a space (the latter guards against id 12 matching 123).
- * @param {object} container - Container instance
- * @param {object} Job - Job model
- * @returns {Promise<object|null>}
- */
-async function findLatestReconfigureJob(container, Job) {
-  const base = reconfigureCommand(container.id);
-  return Job.findOne({
-    where: {
-      [Op.or]: [{ command: base }, { command: { [Op.like]: `${base} %` } }],
-    },
-    order: [['createdAt', 'DESC']],
-  });
-}
-
-/**
- * Prefetch the latest create and reconfigure job for many containers in a single
- * DB query, so resolving N containers' statuses is O(1) queries instead of O(N).
- *
- * Jobs are matched by their deterministic command strings (exact create command,
- * and reconfigure command optionally followed by resource flags) for the given
- * container ids, fetched newest-first, then bucketed per container keeping the
- * first (latest) of each kind.
- *
- * @param {Array<object>} containers - Container instances.
- * @param {object} Job - Job model.
- * @returns {Promise<Map<number, { createJob: object|null, reconfigureJob: object|null }>>}
- */
-async function prefetchLatestJobs(containers, Job) {
-  const byContainer = new Map();
-  const ids = [];
-  for (const c of containers) {
-    byContainer.set(c.id, { createJob: null, reconfigureJob: null });
-    ids.push(c.id);
-  }
-  if (ids.length === 0) return byContainer;
-
-  // One query for all relevant jobs, with a bounded number of WHERE clauses
-  // (independent of N):
-  //   - exact create commands for these ids
-  //   - exact (arg-less) reconfigure commands for these ids
-  //   - any reconfigure command carrying trailing flags (prefix LIKE)
-  // The prefix LIKE may match reconfigure jobs for containers not on this page;
-  // those are discarded during bucketing below (byContainer lookup).
-  const orClauses = [
-    { command: { [Op.in]: ids.map(createCommand) } },
-    { command: { [Op.in]: ids.map(reconfigureCommand) } },
-    { command: { [Op.like]: `${RECONFIGURE_PREFIX}%` } },
-  ];
-  const jobs = await Job.findAll({
-    where: { [Op.or]: orClauses },
-    order: [['createdAt', 'DESC']],
-  });
-
-  // Bucket newest-first; the first job seen for a (container, kind) is the latest.
-  for (const job of jobs) {
-    const id = containerIdFromCommand(job.command);
-    if (id == null) continue;
-    const entry = byContainer.get(id);
-    if (!entry) continue;
-    if (isCreateCommand(job.command)) {
-      if (!entry.createJob) entry.createJob = job;
-    } else if (!entry.reconfigureJob) {
-      entry.reconfigureJob = job;
-    }
-  }
-  return byContainer;
+  if (container.creationJobId) return Job.findByPk(container.creationJobId);
+  return null;
 }
 
 function isActiveJob(job) {
   return !!job && ACTIVE_JOB_STATUSES.includes(job.status);
-}
-
-/**
- * Parse a NUL-separated Proxmox env string ("K=V\0K2=V2") into an object.
- * @param {string|null|undefined} envStr
- * @returns {Object<string,string>}
- */
-function parseEnvString(envStr) {
-  const out = {};
-  if (!envStr) return out;
-  for (const pair of String(envStr).split('\0')) {
-    if (!pair) continue;
-    const eq = pair.indexOf('=');
-    if (eq > 0) out[pair.substring(0, eq)] = pair.substring(eq + 1);
-  }
-  return out;
-}
-
-function shallowEqualMap(a, b) {
-  const ak = Object.keys(a);
-  const bk = Object.keys(b);
-  if (ak.length !== bk.length) return false;
-  for (const k of ak) {
-    if (a[k] !== b[k]) return false;
-  }
-  return true;
-}
-
-/**
- * Compare the env/entrypoint the API server expects against the live LXC config.
- *
- * The expectation is built the same way the reconfigure job builds it
- * (`container.buildLxcEnvConfig()`), so this mirrors exactly what *would* be sent
- * to Proxmox. Env is compared as an unordered set of key=value pairs because the
- * Proxmox API does not preserve ordering. Returns true when the live config
- * matches the expectation (i.e. in sync).
- *
- * @param {object} container - Container instance (provides buildLxcEnvConfig)
- * @param {object} liveConfig - Result of ProxmoxApi.lxcConfig(node, vmid)
- * @returns {boolean} true if in sync, false if drifted
- */
-function configMatches(container, liveConfig) {
-  const expected =
-    typeof container.buildLxcEnvConfig === 'function' ? container.buildLxcEnvConfig() : {};
-  const expectedDeletes = new Set(
-    (expected.delete ? String(expected.delete).split(',') : []).map((s) => s.trim()),
-  );
-
-  // --- entrypoint ---
-  const liveEntrypoint = liveConfig?.entrypoint || null;
-  if (expectedDeletes.has('entrypoint')) {
-    if (liveEntrypoint) return false; // expected absent, but present live
-  } else if ((expected.entrypoint || null) !== liveEntrypoint) {
-    return false;
-  }
-
-  // --- env ---
-  const liveEnv = parseEnvString(liveConfig?.env);
-  if (expectedDeletes.has('env')) {
-    if (Object.keys(liveEnv).length > 0) return false; // expected none, but some live
-  } else {
-    const expectedEnv = parseEnvString(expected.env);
-    if (!shallowEqualMap(expectedEnv, liveEnv)) return false;
-  }
-
-  return true;
 }
 
 /**
@@ -254,23 +83,17 @@ function findInSnapshot(snapshot, vmid) {
  * @param {boolean} facts.proxmoxReachable - Whether Proxmox was queried OK.
  * @param {boolean} facts.inProxmox - Whether the LXC exists in Proxmox.
  * @param {boolean} facts.proxmoxRunning - Whether the LXC is running.
- * @param {boolean} facts.inSync - Whether the live config matches expectation.
  * @param {boolean} facts.hasVmid - Whether the container has a Proxmox VMID.
  * @param {boolean} facts.creating - Active create job present.
- * @param {boolean} facts.restarting - Active reconfigure job present.
- * @param {boolean} facts.createFailed - Latest create job returned failure.
- * @param {boolean} facts.hasCreateJob - A create job exists at all.
+ * @param {boolean} facts.createFailed - Create job returned failure.
  * @returns {string} STATUS value
  */
 function decideStatus(facts) {
   if (facts.inProxmox) {
-    if (facts.restarting) return STATUS.RESTARTING;
-    if (facts.inSync === false) return STATUS.OUT_OF_SYNC;
     return facts.proxmoxRunning ? STATUS.RUNNING : STATUS.OFFLINE;
   }
 
   if (facts.creating) return STATUS.CREATING;
-  if (facts.restarting) return STATUS.RESTARTING;
 
   // We had a VMID + creds but couldn't reach Proxmox: don't guess missing.
   if (facts.hasVmid && !facts.proxmoxReachable) return STATUS.UNKNOWN;
@@ -283,29 +106,20 @@ function decideStatus(facts) {
  * Compute the live status of a single container.
  *
  * @param {object} params
- * @param {object} params.container - Container instance (with `node` association).
+ * @param {object} params.container - Container instance (with `node` association,
+ *   and ideally the `creationJob` association eager-loaded).
  * @param {object} params.Job - Job model (from models).
  * @param {object} [params.api] - Optional pre-authenticated ProxmoxApi client for
  *   the container's node (lets callers reuse one client across many containers).
  * @param {{ data: Array<object>, ok: boolean }} [params.snapshot] - Optional
  *   pre-fetched clusterResources('lxc') snapshot for the node. `ok` indicates the
  *   query succeeded; `data` is the resource list (used for batching the index).
- * @param {{ createJob: object|null, reconfigureJob: object|null }} [params.jobs] -
- *   Optional prefetched latest create/reconfigure jobs for this container (see
- *   prefetchLatestJobs). When provided, the per-container job DB lookups are
- *   skipped, making batch resolution O(1) queries instead of O(N).
  * @returns {Promise<string>} One of the STATUS values.
  */
-async function computeContainerStatus({ container, Job, api, snapshot, jobs }) {
+async function computeContainerStatus({ container, Job, api, snapshot }) {
   const node = container.node;
   const hasCreds = nodeHasCreds(node);
   const hasVmid = container.containerId != null;
-
-  let client = api || null;
-  async function getClient() {
-    if (!client) client = await node.api();
-    return client;
-  }
 
   // --- Determine Proxmox presence / run state ---
   let proxmoxReachable = false;
@@ -319,8 +133,9 @@ async function computeContainerStatus({ container, Job, api, snapshot, jobs }) {
         proxmoxReachable = !!snapshot.ok;
         resources = snapshot.ok ? snapshot.data : null;
       } else {
-        const c = await getClient();
-        resources = await c.clusterResources('lxc');
+        // Single-container path (no shared snapshot): fetch this node's once.
+        const client = api || (await node.api());
+        resources = await client.clusterResources('lxc');
         proxmoxReachable = true;
       }
       if (proxmoxReachable) {
@@ -335,33 +150,13 @@ async function computeContainerStatus({ container, Job, api, snapshot, jobs }) {
     }
   }
 
-  // --- Jobs ---
-  // Use prefetched jobs when supplied (batch path); otherwise query per container.
-  const reconfigureJob = jobs
-    ? jobs.reconfigureJob
-    : await findLatestReconfigureJob(container, Job);
-  const restarting = isActiveJob(reconfigureJob);
-
-  // Drift detection (only meaningful if it exists and isn't already restarting).
-  let inSync = null;
-  if (inProxmox && !restarting && hasCreds) {
-    try {
-      const c = await getClient();
-      const liveConfig = await c.lxcConfig(node.name, container.containerId);
-      inSync = configMatches(container, liveConfig);
-    } catch (err) {
-      inSync = null; // can't assert drift
-    }
-  }
-
-  // Only look up the create job when we actually need it (container not running
-  // in Proxmox), to avoid an extra query on the happy path.
+  // Only inspect the create job when the container isn't in Proxmox, to
+  // distinguish creating / failed / missing. The create job is linked by FK
+  // (creationJobId), so this is a cheap PK lookup or free when eager-loaded.
   let creating = false;
   let createFailed = false;
-  let hasCreateJob = false;
   if (!inProxmox) {
-    const createJob = jobs ? jobs.createJob : await findLatestCreateJob(container, Job);
-    hasCreateJob = !!createJob;
+    const createJob = await findCreateJob(container, Job);
     creating = isActiveJob(createJob);
     createFailed = !!createJob && createJob.status === 'failure';
   }
@@ -370,34 +165,28 @@ async function computeContainerStatus({ container, Job, api, snapshot, jobs }) {
     proxmoxReachable,
     inProxmox,
     proxmoxRunning,
-    inSync,
     hasVmid,
     creating,
-    restarting,
     createFailed,
-    hasCreateJob,
   });
 }
 
 /**
  * Compute live statuses for many containers efficiently.
  *
- * Two batching strategies keep this fast for the list page:
- *   - Jobs: a single DB query fetches the latest create/reconfigure job for every
- *     container up front (O(1) queries instead of O(N)).
+ * No per-container Proxmox calls and no per-container DB queries are issued:
  *   - Proxmox: containers are grouped by node so each node's
- *     `clusterResources('lxc')` snapshot is fetched exactly once and a single
- *     authenticated client is reused for that node's containers.
+ *     `clusterResources('lxc')` snapshot is fetched exactly once.
+ *   - Create job: resolved from each container's eager-loaded `creationJob`
+ *     association (or its creationJobId FK).
  *
- * @param {Array<object>} containers - Container instances (each with `node`).
+ * @param {Array<object>} containers - Container instances (each with `node`, and
+ *   ideally the `creationJob` association loaded to avoid per-container queries).
  * @param {object} Job - Job model.
  * @returns {Promise<Map<number,string>>} Map of container.id -> STATUS value.
  */
 async function computeContainerStatuses(containers, Job) {
   const result = new Map();
-
-  // One query for everyone's latest create/reconfigure jobs.
-  const jobsByContainer = await prefetchLatestJobs(containers, Job);
 
   // Group by node id (containers without a node still get resolved, just without
   // any Proxmox facts).
@@ -411,12 +200,11 @@ async function computeContainerStatuses(containers, Job) {
   await Promise.all(
     Array.from(byNode.values()).map(async (group) => {
       const node = group[0].node;
-      let api = null;
       let snapshot = { ok: false, data: null };
 
       if (nodeHasCreds(node)) {
         try {
-          api = await node.api();
+          const api = await node.api();
           const data = await api.clusterResources('lxc');
           snapshot = { ok: true, data };
         } catch (err) {
@@ -424,15 +212,11 @@ async function computeContainerStatuses(containers, Job) {
         }
       }
 
-      // Resolve each container in the group sequentially per node (shares the
-      // single authenticated client); different nodes run in parallel.
+      // Resolution is now CPU-only per container (no Proxmox/DB I/O when the
+      // create job is eager-loaded), so the snapshot is reused for all of them.
       for (const container of group) {
-        const jobs = jobsByContainer.get(container.id) || {
-          createJob: null,
-          reconfigureJob: null,
-        };
         // eslint-disable-next-line no-await-in-loop
-        const status = await computeContainerStatus({ container, Job, api, snapshot, jobs });
+        const status = await computeContainerStatus({ container, Job, snapshot });
         result.set(container.id, status);
       }
     }),
@@ -448,11 +232,6 @@ module.exports = {
   computeContainerStatuses,
   decideStatus,
   // exported for reuse / testing
-  configMatches,
-  parseEnvString,
   findInSnapshot,
-  findLatestCreateJob,
-  findLatestReconfigureJob,
-  prefetchLatestJobs,
-  containerIdFromCommand,
+  findCreateJob,
 };

--- a/create-a-container/utils/container-status.js
+++ b/create-a-container/utils/container-status.js
@@ -1,0 +1,355 @@
+/**
+ * container-status.js — resolve the *live* status of a container.
+ *
+ * Historically the container "status" was a static column in the database that
+ * was only mutated by the create/reconfigure job scripts. That value drifts out
+ * of reality whenever something changes a container directly in Proxmox (or when
+ * a job dies without updating the row). This module computes the real status on
+ * demand by combining three sources of truth:
+ *
+ *   1. Proxmox  — does the LXC exist, and is it running or stopped?
+ *   2. Jobs     — is there an active create/restart job, or did the last create
+ *                 job fail?
+ *   3. Config   — does the live LXC config match what the API server expects?
+ *
+ * Resolved statuses (a strict superset of the old running/offline values):
+ *   running      — exists in Proxmox and is online
+ *   offline      — exists in Proxmox but is stopped
+ *   restarting   — has an active (pending/running) reconfigure job
+ *   creating     — not in Proxmox, but has an active (pending/running) create job
+ *   failed       — not in Proxmox, last create job returned failure
+ *   missing      — not in Proxmox, create job succeeded or no create job found
+ *   out-of-sync  — exists in Proxmox but its config doesn't match expectation
+ *   unknown      — Proxmox could not be reached / node has no API credentials
+ */
+
+const { Op } = require('sequelize');
+
+const STATUS = Object.freeze({
+  RUNNING: 'running',
+  OFFLINE: 'offline',
+  CREATING: 'creating',
+  RESTARTING: 'restarting',
+  FAILED: 'failed',
+  MISSING: 'missing',
+  OUT_OF_SYNC: 'out-of-sync',
+  UNKNOWN: 'unknown',
+});
+
+const STATUS_VALUES = Object.freeze(Object.values(STATUS));
+
+// Job command fragments that identify create vs reconfigure (restart) jobs.
+// Jobs are distinguished solely by their `command` string (no type column).
+const CREATE_CMD = 'bin/create-container.js';
+const RECONFIGURE_CMD = 'bin/reconfigure-container.js';
+
+const ACTIVE_JOB_STATUSES = ['pending', 'running'];
+
+function nodeHasCreds(node) {
+  return !!(node && node.apiUrl && node.tokenId && node.secret);
+}
+
+/**
+ * Find the most recent create job for a container.
+ * Prefers the explicit creationJobId FK; falls back to a command-string match.
+ * @param {object} container - Container instance (with optional creationJob assoc)
+ * @param {object} Job - Job model
+ * @returns {Promise<object|null>}
+ */
+async function findLatestCreateJob(container, Job) {
+  if (container.creationJob) return container.creationJob;
+  if (container.creationJobId) {
+    return Job.findByPk(container.creationJobId);
+  }
+  return Job.findOne({
+    where: { command: { [Op.like]: `%${CREATE_CMD} --container-id=${container.id}%` } },
+    order: [['createdAt', 'DESC']],
+  });
+}
+
+/**
+ * Find the most recent reconfigure (restart) job for a container, if any.
+ * @param {object} container - Container instance
+ * @param {object} Job - Job model
+ * @returns {Promise<object|null>}
+ */
+async function findLatestReconfigureJob(container, Job) {
+  return Job.findOne({
+    where: { command: { [Op.like]: `%${RECONFIGURE_CMD} --container-id=${container.id}%` } },
+    order: [['createdAt', 'DESC']],
+  });
+}
+
+function isActiveJob(job) {
+  return !!job && ACTIVE_JOB_STATUSES.includes(job.status);
+}
+
+/**
+ * Parse a NUL-separated Proxmox env string ("K=V\0K2=V2") into an object.
+ * @param {string|null|undefined} envStr
+ * @returns {Object<string,string>}
+ */
+function parseEnvString(envStr) {
+  const out = {};
+  if (!envStr) return out;
+  for (const pair of String(envStr).split('\0')) {
+    if (!pair) continue;
+    const eq = pair.indexOf('=');
+    if (eq > 0) out[pair.substring(0, eq)] = pair.substring(eq + 1);
+  }
+  return out;
+}
+
+function shallowEqualMap(a, b) {
+  const ak = Object.keys(a);
+  const bk = Object.keys(b);
+  if (ak.length !== bk.length) return false;
+  for (const k of ak) {
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+}
+
+/**
+ * Compare the env/entrypoint the API server expects against the live LXC config.
+ *
+ * The expectation is built the same way the reconfigure job builds it
+ * (`container.buildLxcEnvConfig()`), so this mirrors exactly what *would* be sent
+ * to Proxmox. Env is compared as an unordered set of key=value pairs because the
+ * Proxmox API does not preserve ordering. Returns true when the live config
+ * matches the expectation (i.e. in sync).
+ *
+ * @param {object} container - Container instance (provides buildLxcEnvConfig)
+ * @param {object} liveConfig - Result of ProxmoxApi.lxcConfig(node, vmid)
+ * @returns {boolean} true if in sync, false if drifted
+ */
+function configMatches(container, liveConfig) {
+  const expected =
+    typeof container.buildLxcEnvConfig === 'function' ? container.buildLxcEnvConfig() : {};
+  const expectedDeletes = new Set(
+    (expected.delete ? String(expected.delete).split(',') : []).map((s) => s.trim()),
+  );
+
+  // --- entrypoint ---
+  const liveEntrypoint = liveConfig?.entrypoint || null;
+  if (expectedDeletes.has('entrypoint')) {
+    if (liveEntrypoint) return false; // expected absent, but present live
+  } else if ((expected.entrypoint || null) !== liveEntrypoint) {
+    return false;
+  }
+
+  // --- env ---
+  const liveEnv = parseEnvString(liveConfig?.env);
+  if (expectedDeletes.has('env')) {
+    if (Object.keys(liveEnv).length > 0) return false; // expected none, but some live
+  } else {
+    const expectedEnv = parseEnvString(expected.env);
+    if (!shallowEqualMap(expectedEnv, liveEnv)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Locate a container in a cluster-resources snapshot by VMID.
+ * @param {Array<object>|null} snapshot - Result of ProxmoxApi.clusterResources('lxc')
+ * @param {number} vmid
+ * @returns {object|null} The matching resource entry or null
+ */
+function findInSnapshot(snapshot, vmid) {
+  if (!Array.isArray(snapshot) || vmid == null) return null;
+  return snapshot.find((r) => Number(r.vmid) === Number(vmid)) || null;
+}
+
+/**
+ * Resolve status from already-gathered facts. Pure function — no I/O — so it is
+ * trivial to unit test and is the single source of the decision tree.
+ *
+ * @param {object} facts
+ * @param {boolean} facts.proxmoxReachable - Whether Proxmox was queried OK.
+ * @param {boolean} facts.inProxmox - Whether the LXC exists in Proxmox.
+ * @param {boolean} facts.proxmoxRunning - Whether the LXC is running.
+ * @param {boolean} facts.inSync - Whether the live config matches expectation.
+ * @param {boolean} facts.hasVmid - Whether the container has a Proxmox VMID.
+ * @param {boolean} facts.creating - Active create job present.
+ * @param {boolean} facts.restarting - Active reconfigure job present.
+ * @param {boolean} facts.createFailed - Latest create job returned failure.
+ * @param {boolean} facts.hasCreateJob - A create job exists at all.
+ * @returns {string} STATUS value
+ */
+function decideStatus(facts) {
+  if (facts.inProxmox) {
+    if (facts.restarting) return STATUS.RESTARTING;
+    if (facts.inSync === false) return STATUS.OUT_OF_SYNC;
+    return facts.proxmoxRunning ? STATUS.RUNNING : STATUS.OFFLINE;
+  }
+
+  if (facts.creating) return STATUS.CREATING;
+  if (facts.restarting) return STATUS.RESTARTING;
+
+  // We had a VMID + creds but couldn't reach Proxmox: don't guess missing.
+  if (facts.hasVmid && !facts.proxmoxReachable) return STATUS.UNKNOWN;
+
+  if (facts.createFailed) return STATUS.FAILED;
+  return STATUS.MISSING;
+}
+
+/**
+ * Compute the live status of a single container.
+ *
+ * @param {object} params
+ * @param {object} params.container - Container instance (with `node` association).
+ * @param {object} params.Job - Job model (from models).
+ * @param {object} [params.api] - Optional pre-authenticated ProxmoxApi client for
+ *   the container's node (lets callers reuse one client across many containers).
+ * @param {{ data: Array<object>, ok: boolean }} [params.snapshot] - Optional
+ *   pre-fetched clusterResources('lxc') snapshot for the node. `ok` indicates the
+ *   query succeeded; `data` is the resource list (used for batching the index).
+ * @returns {Promise<string>} One of the STATUS values.
+ */
+async function computeContainerStatus({ container, Job, api, snapshot }) {
+  const node = container.node;
+  const hasCreds = nodeHasCreds(node);
+  const hasVmid = container.containerId != null;
+
+  let client = api || null;
+  async function getClient() {
+    if (!client) client = await node.api();
+    return client;
+  }
+
+  // --- Determine Proxmox presence / run state ---
+  let proxmoxReachable = false;
+  let inProxmox = false;
+  let proxmoxRunning = false;
+
+  if (hasVmid && hasCreds) {
+    try {
+      let resources;
+      if (snapshot) {
+        proxmoxReachable = !!snapshot.ok;
+        resources = snapshot.ok ? snapshot.data : null;
+      } else {
+        const c = await getClient();
+        resources = await c.clusterResources('lxc');
+        proxmoxReachable = true;
+      }
+      if (proxmoxReachable) {
+        const resource = findInSnapshot(resources, container.containerId);
+        if (resource) {
+          inProxmox = true;
+          proxmoxRunning = resource.status === 'running';
+        }
+      }
+    } catch (err) {
+      proxmoxReachable = false;
+    }
+  }
+
+  // --- Jobs ---
+  const reconfigureJob = await findLatestReconfigureJob(container, Job);
+  const restarting = isActiveJob(reconfigureJob);
+
+  // Drift detection (only meaningful if it exists and isn't already restarting).
+  let inSync = null;
+  if (inProxmox && !restarting && hasCreds) {
+    try {
+      const c = await getClient();
+      const liveConfig = await c.lxcConfig(node.name, container.containerId);
+      inSync = configMatches(container, liveConfig);
+    } catch (err) {
+      inSync = null; // can't assert drift
+    }
+  }
+
+  // Only look up the create job when we actually need it (container not running
+  // in Proxmox), to avoid an extra query on the happy path.
+  let creating = false;
+  let createFailed = false;
+  let hasCreateJob = false;
+  if (!inProxmox) {
+    const createJob = await findLatestCreateJob(container, Job);
+    hasCreateJob = !!createJob;
+    creating = isActiveJob(createJob);
+    createFailed = !!createJob && createJob.status === 'failure';
+  }
+
+  return decideStatus({
+    proxmoxReachable,
+    inProxmox,
+    proxmoxRunning,
+    inSync,
+    hasVmid,
+    creating,
+    restarting,
+    createFailed,
+    hasCreateJob,
+  });
+}
+
+/**
+ * Compute live statuses for many containers efficiently.
+ *
+ * Groups containers by node so each node's Proxmox `clusterResources('lxc')`
+ * snapshot is fetched exactly once and a single authenticated client is reused
+ * for that node's containers (including per-container config reads). This keeps
+ * total end-user latency low for the list page versus N independent calls.
+ *
+ * @param {Array<object>} containers - Container instances (each with `node`).
+ * @param {object} Job - Job model.
+ * @returns {Promise<Map<number,string>>} Map of container.id -> STATUS value.
+ */
+async function computeContainerStatuses(containers, Job) {
+  const result = new Map();
+
+  // Group by node id (containers without a node still get resolved, just without
+  // any Proxmox facts).
+  const byNode = new Map();
+  for (const container of containers) {
+    const key = container.node ? container.node.id : `__no_node_${container.id}`;
+    if (!byNode.has(key)) byNode.set(key, []);
+    byNode.get(key).push(container);
+  }
+
+  await Promise.all(
+    Array.from(byNode.values()).map(async (group) => {
+      const node = group[0].node;
+      let api = null;
+      let snapshot = { ok: false, data: null };
+
+      if (nodeHasCreds(node)) {
+        try {
+          api = await node.api();
+          const data = await api.clusterResources('lxc');
+          snapshot = { ok: true, data };
+        } catch (err) {
+          snapshot = { ok: false, data: null };
+        }
+      }
+
+      // Resolve each container in the group sequentially per node (shares the
+      // single authenticated client); different nodes run in parallel.
+      for (const container of group) {
+        // eslint-disable-next-line no-await-in-loop
+        const status = await computeContainerStatus({ container, Job, api, snapshot });
+        result.set(container.id, status);
+      }
+    }),
+  );
+
+  return result;
+}
+
+module.exports = {
+  STATUS,
+  STATUS_VALUES,
+  computeContainerStatus,
+  computeContainerStatuses,
+  decideStatus,
+  // exported for reuse / testing
+  configMatches,
+  parseEnvString,
+  findInSnapshot,
+  findLatestCreateJob,
+  findLatestReconfigureJob,
+};

--- a/create-a-container/utils/container-status.js
+++ b/create-a-container/utils/container-status.js
@@ -38,10 +38,17 @@ const STATUS = Object.freeze({
 
 const STATUS_VALUES = Object.freeze(Object.values(STATUS));
 
-// Job command fragments that identify create vs reconfigure (restart) jobs.
-// Jobs are distinguished solely by their `command` string (no type column).
-const CREATE_CMD = 'bin/create-container.js';
-const RECONFIGURE_CMD = 'bin/reconfigure-container.js';
+// Job command builders. Jobs are distinguished solely by their `command` string
+// (no type column), and the commands are constructed deterministically by the
+// container router / resource-requests, so we match them exactly here.
+//   create:      node bin/create-container.js --container-id=<id>
+//   reconfigure: node bin/reconfigure-container.js --container-id=<id>[ --<resource>=<value>...]
+function createCommand(id) {
+  return `node bin/create-container.js --container-id=${id}`;
+}
+function reconfigureCommand(id) {
+  return `node bin/reconfigure-container.js --container-id=${id}`;
+}
 
 const ACTIVE_JOB_STATUSES = ['pending', 'running'];
 
@@ -50,40 +57,9 @@ function nodeHasCreds(node) {
 }
 
 /**
- * Escape a string for safe use inside a RegExp.
- * @param {string|number} s
- * @returns {string}
- */
-function escapeRegExp(s) {
-  return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/**
- * Find the most recent job for a container whose command contains
- * `<cmdFragment> --container-id=<id>` as a *whole* argument.
- *
- * A plain SQL LIKE on `--container-id=<id>` would also match longer ids
- * (id 12 matches `--container-id=123`), so we use LIKE only to narrow at the DB
- * level (ordered most-recent first) and then confirm each candidate in JS with a
- * regex requiring the id to be terminated by a space or end-of-string.
- *
- * @param {object} Job - Job model
- * @param {string} cmdFragment - e.g. CREATE_CMD or RECONFIGURE_CMD
- * @param {number} id - Container database id
- * @returns {Promise<object|null>}
- */
-async function findLatestJobForContainer(Job, cmdFragment, id) {
-  const candidates = await Job.findAll({
-    where: { command: { [Op.like]: `%${cmdFragment} --container-id=${id}%` } },
-    order: [['createdAt', 'DESC']],
-  });
-  const whole = new RegExp(`${escapeRegExp(cmdFragment)} --container-id=${escapeRegExp(id)}(?:\\s|$)`);
-  return candidates.find((job) => whole.test(job.command)) || null;
-}
-
-/**
  * Find the most recent create job for a container.
- * Prefers the explicit creationJobId FK; falls back to a command-string match.
+ * Prefers the explicit creationJobId FK; falls back to an exact command match.
+ * Create commands never carry trailing arguments, so the match is exact.
  * @param {object} container - Container instance (with optional creationJob assoc)
  * @param {object} Job - Job model
  * @returns {Promise<object|null>}
@@ -93,17 +69,29 @@ async function findLatestCreateJob(container, Job) {
   if (container.creationJobId) {
     return Job.findByPk(container.creationJobId);
   }
-  return findLatestJobForContainer(Job, CREATE_CMD, container.id);
+  return Job.findOne({
+    where: { command: createCommand(container.id) },
+    order: [['createdAt', 'DESC']],
+  });
 }
 
 /**
  * Find the most recent reconfigure (restart) job for a container, if any.
+ * A reconfigure command is either exactly `<cmd> --container-id=<id>` or that
+ * followed by ` --<resource>=<value>` flags, so we match the exact form OR the
+ * exact form followed by a space (the latter guards against id 12 matching 123).
  * @param {object} container - Container instance
  * @param {object} Job - Job model
  * @returns {Promise<object|null>}
  */
 async function findLatestReconfigureJob(container, Job) {
-  return findLatestJobForContainer(Job, RECONFIGURE_CMD, container.id);
+  const base = reconfigureCommand(container.id);
+  return Job.findOne({
+    where: {
+      [Op.or]: [{ command: base }, { command: { [Op.like]: `${base} %` } }],
+    },
+    order: [['createdAt', 'DESC']],
+  });
 }
 
 function isActiveJob(job) {


### PR DESCRIPTION
Resolves #350.

## Summary

Container status was a static `Containers.status` column updated only by the create/reconfigure job scripts, so it drifted from reality whenever Proxmox changed out of band or a job died mid-run. This replaces it with status **computed live on demand**, embedded directly on the existing container API payloads. The static column is dropped.

### Live status resolver — `create-a-container/utils/container-status.js`
Status is derived from two cheap sources of truth:
- **Proxmox run-state** — does the LXC exist and is it running/stopped? Read from a single `clusterResources('lxc')` snapshot **per node**.
- **Create job** — for containers not yet in Proxmox: is the create job active, did it fail, or is it gone? The create job is linked by the `creationJobId` foreign key, so this is resolved from the eager-loaded `creationJob` association (zero extra queries) or a single PK lookup.

Resolved statuses:

| Status | Condition |
|---|---|
| `running` | online in Proxmox |
| `offline` | exists in Proxmox but stopped |
| `creating` | no Proxmox VM yet, active create job |
| `failed` | no Proxmox VM, create job returned failure |
| `missing` | no Proxmox VM, create succeeded or no create job found |
| `unknown` | Proxmox unreachable / node has no API credentials |

### Where status is returned
The live `status` is embedded on the existing **list**, **show**, and **create** container payloads — no new endpoint.

> Earlier revisions of this PR also implemented `restarting` (active reconfigure job) and `out-of-sync` (live LXC config differs from expectation), plus a dedicated `GET /containers/:id/status` endpoint. All three were **removed** for performance/simplicity (see below). The PUT endpoint still enqueues a reconfigure job and returns its `jobId`; only the `restarting` status *label* is gone.

### Performance (why the scope was trimmed)
Resolving the list must stay cheap. Two things were inherently O(N):
- **Reconfigure-job lookups** (for `restarting`) — reconfigure jobs have no FK, so detecting them needed per-container command-string queries.
- **Config-drift reads** (for `out-of-sync`) — Proxmox has **no bulk config endpoint**, so this needed one `lxcConfig` call per in-Proxmox container.

Both were dropped. The index now issues **one Proxmox call per node** and **zero per-container Proxmox or DB job queries** (verified at 30 containers). The create job comes free from the eager-loaded association.

### Compatibility
- `status` remains present on the same endpoints, so existing consumers keep working. Checked `mieweb/launchpad` (an external API client): it only checks `status == "running"` and never uses `restarting`/`out-of-sync`, so dropping them is safe there.
- This narrows the status set vs. what `main` could emit (`main` could return `restarting`), so it's not a strict superset anymore — but no known client depends on the removed values.

### Removed the static column
- Migration `20260615000000-remove-container-status.js` drops `Containers.status`; removed from the model.
- All former writers updated to stop persisting status (`create-container.js`, `reconfigure-container.js`, `nodes.js` import, `json-to-sql.js`). Failure is now captured by the job's `failure` status.
- The create-time `status !== 'pending'` guard became a Proxmox-VMID-presence guard.
- `routers/templates.js` (nginx/dnsmasq config) previously filtered `where: { status: 'running' }`; it now selects routable containers by `ipv4Address != null`.
- `routers/api/v1/resource-requests.js` (`applyResourceToExistingContainers`) previously filtered `where: { ..., status: 'running' }` — that would have thrown "Unknown column 'status'" after the migration. It now filters on `containerId != null` (a VMID is required to reconfigure anyway).

### Frontend
- Typed `ContainerStatus` union; the list page renders the live status from the list response via a small presentational `StatusBadge` (friendly labels + status → badge-variant mapping). No per-row polling.

### Docs
- OpenAPI: `ContainerStatus` enum, referenced from the `Container` schema.
- README: ER diagram (removed `status`) and a container-status field description.

## Testing
No test framework exists in the repo, so logic was validated with standalone Node assertion scripts (not committed):
- Decision-table assertions for every status path.
- Batch-resolution assertions confirming **0** per-container Proxmox/DB calls and **1** cluster snapshot per node at scale (30 containers).
- All backend files pass `node --check`; OpenAPI YAML parses; client `type-check` and `build` pass.

## Notes / follow-ups
- This drops a DB column, so coordinate with deploy/migration timing.
- Config-drift (`out-of-sync`) can be revisited later if Proxmox gains a bulk config endpoint or if drift is computed lazily on the detail view / cached.
- Happy to add a `prove`/test harness if the team wants committed tests.