### PR TITLE
Feature: "All containers" toggle for admins sitewide; add additional docker build failsafe's. 

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -28,39 +28,15 @@ services:
           skopeo copy docker://$${IMAGE_REF} oci-archive:$${FILENAME}
         fi
 
-  # This service runs once when bringing the compose stack up to ensure the
-  # node_modules are populated in the user's create-a-container directory. This
-  # is usually handled by the manager's Dockerfile, but we're mounting over that
-  # directory so we need to be sure the user has them.
-  #
-  # This is the SINGLE owner of `npm ci` for both the server and the client.
-  # The `client` service below must NOT also run `npm ci`, otherwise two
-  # concurrent installs race on the same bind-mounted node_modules and wipe the
-  # .bin symlinks (manifesting as "tsc: not found" / "vite: not found").
-  #
-  # We install the FULL dependency tree (no --omit=dev) because the Proxmox dev
-  # systemd override runs node_modules/.bin/nodemon, and nodemon is a
-  # devDependency. The catch is another devDependency, @vscode/sqlite3 (the
-  # local-dev sqlite driver), is a native module that builds from source via
-  # node-gyp and would need Python + a C/C++ toolchain this slim image lacks.
-  # --ignore-scripts skips that build (and every other lifecycle script) so the
-  # install can't fail on it; bin symlinks like nodemon are still created
-  # because linking is not a lifecycle script. This stack runs against
-  # PostgreSQL and only require()s @vscode/sqlite3 lazily for the sqlite dialect,
-  # so leaving it unbuilt is harmless. We then run patch-package by hand to
-  # re-apply patches/ (e.g. the sequelize patch) that the skipped postinstall
-  # would have applied.
   node:
-    image: node:24-trixie-slim
+    image: node:24-trixie
     volumes:
       - ./:/opt/opensource-server
     working_dir: /opt/opensource-server/create-a-container
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
-        npm ci --ignore-scripts --no-audit --no-fund
-        ./node_modules/.bin/patch-package
-        exec npm --prefix client ci --no-audit --no-fund
+        exec npm ci --no-audit --no-fund
 
   # Watches the React client and rebuilds the production bundle on change. The
   # Manager LXC inside Proxmox serves create-a-container/client/dist statically
@@ -79,17 +55,14 @@ services:
       - ./:/opt/opensource-server
     working_dir: /opt/opensource-server/create-a-container/client
     entrypoint: ["/bin/sh", "-c"]
-    # No `npm ci` here: the `node` service is the single install owner. Running
-    # it again concurrently would race on the shared bind-mounted node_modules
-    # and remove the tsc/vite bin symlinks. We wait for `node` to finish, then
-    # build once and watch.
+    # Owns the client's node_modules install (separate directory from the
+    # server, so it runs in parallel with the `node` service). Then builds once
+    # and watches.
     command:
       - |
+        npm ci --no-audit --no-fund
         npm run build
         exec npm run build:watch
-    depends_on:
-      node:
-        condition: service_completed_successfully
     # Healthy once an initial bundle exists, so Proxmox can wait for it on a
     # fresh checkout (where client/dist isn't present yet) before serving.
     healthcheck:

--- a/compose.yml
+++ b/compose.yml
@@ -28,6 +28,10 @@ services:
           skopeo copy docker://$${IMAGE_REF} oci-archive:$${FILENAME}
         fi
 
+# This service runs once when bringing the compose stack up to ensure the
+# node_modules are populated in the user's create-a-container directory. This
+# is usually handled by the manager's Dockerfile, but we're mounting over that
+# directory so we need to be sure that the user has them.
   node:
     image: node:24-trixie
     volumes:

--- a/compose.yml
+++ b/compose.yml
@@ -32,6 +32,24 @@ services:
   # node_modules are populated in the user's create-a-container directory. This
   # is usually handled by the manager's Dockerfile, but we're mounting over that
   # directory so we need to be sure the user has them.
+  #
+  # This is the SINGLE owner of `npm ci` for both the server and the client.
+  # The `client` service below must NOT also run `npm ci`, otherwise two
+  # concurrent installs race on the same bind-mounted node_modules and wipe the
+  # .bin symlinks (manifesting as "tsc: not found" / "vite: not found").
+  #
+  # We install the FULL dependency tree (no --omit=dev) because the Proxmox dev
+  # systemd override runs node_modules/.bin/nodemon, and nodemon is a
+  # devDependency. The catch is another devDependency, @vscode/sqlite3 (the
+  # local-dev sqlite driver), is a native module that builds from source via
+  # node-gyp and would need Python + a C/C++ toolchain this slim image lacks.
+  # --ignore-scripts skips that build (and every other lifecycle script) so the
+  # install can't fail on it; bin symlinks like nodemon are still created
+  # because linking is not a lifecycle script. This stack runs against
+  # PostgreSQL and only require()s @vscode/sqlite3 lazily for the sqlite dialect,
+  # so leaving it unbuilt is harmless. We then run patch-package by hand to
+  # re-apply patches/ (e.g. the sequelize patch) that the skipped postinstall
+  # would have applied.
   node:
     image: node:24-trixie-slim
     volumes:
@@ -40,7 +58,8 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
-        npm ci --omit=dev --no-audit --no-fund
+        npm ci --ignore-scripts --no-audit --no-fund
+        ./node_modules/.bin/patch-package
         exec npm --prefix client ci --no-audit --no-fund
 
   # Watches the React client and rebuilds the production bundle on change. The
@@ -60,11 +79,17 @@ services:
       - ./:/opt/opensource-server
     working_dir: /opt/opensource-server/create-a-container/client
     entrypoint: ["/bin/sh", "-c"]
+    # No `npm ci` here: the `node` service is the single install owner. Running
+    # it again concurrently would race on the shared bind-mounted node_modules
+    # and remove the tsc/vite bin symlinks. We wait for `node` to finish, then
+    # build once and watch.
     command:
       - |
-        npm ci --no-audit --no-fund
         npm run build
         exec npm run build:watch
+    depends_on:
+      node:
+        condition: service_completed_successfully
     # Healthy once an initial bundle exists, so Proxmox can wait for it on a
     # fresh checkout (where client/dist isn't present yet) before serving.
     healthcheck:

--- a/create-a-container/client/src/app/router.tsx
+++ b/create-a-container/client/src/app/router.tsx
@@ -53,6 +53,7 @@ export const router = createBrowserRouter([
           { path: '/sites/:id/edit', element: <SiteFormPage /> },
 
           { path: '/sites/:siteId/containers', element: <ContainersListPage /> },
+          { path: '/sites/:siteId/containers/all', element: <ContainersListPage scope="all" /> },
           { path: '/sites/:siteId/containers/new', element: <ContainerFormPage /> },
           { path: '/sites/:siteId/containers/:id/edit', element: <ContainerFormPage /> },
 

--- a/create-a-container/client/src/app/router.tsx
+++ b/create-a-container/client/src/app/router.tsx
@@ -53,7 +53,6 @@ export const router = createBrowserRouter([
           { path: '/sites/:id/edit', element: <SiteFormPage /> },
 
           { path: '/sites/:siteId/containers', element: <ContainersListPage /> },
-          { path: '/sites/:siteId/containers/all', element: <ContainersListPage scope="all" /> },
           { path: '/sites/:siteId/containers/new', element: <ContainerFormPage /> },
           { path: '/sites/:siteId/containers/:id/edit', element: <ContainerFormPage /> },
 

--- a/create-a-container/client/src/lib/queries.ts
+++ b/create-a-container/client/src/lib/queries.ts
@@ -26,9 +26,8 @@ export const keys = {
   nodes: (siteId: number | string) => ['sites', String(siteId), 'nodes'] as const,
   node: (siteId: number | string, id: number | string) =>
     ['sites', String(siteId), 'nodes', String(id)] as const,
-  containers: (siteId: number | string) => ['sites', String(siteId), 'containers'] as const,
-  containersAll: (siteId: number | string, params?: Record<string, string | undefined>) =>
-    ['sites', String(siteId), 'containers', 'all', params ?? {}] as const,
+  containers: (siteId: number | string, params?: Record<string, string | undefined>) =>
+    ['sites', String(siteId), 'containers', params ?? {}] as const,
   container: (siteId: number | string, id: number | string) =>
     ['sites', String(siteId), 'containers', String(id)] as const,
   containerBootstrap: (siteId: number | string) =>
@@ -62,17 +61,19 @@ export const queries = {
     api.get<Node>(`/api/v1/sites/${siteId}/nodes/${id}`),
 
   // Containers
-  listContainers: (siteId: number | string) =>
-    api.get<Container[]>(`/api/v1/sites/${siteId}/containers`),
-  listAllContainers: (
+  listContainers: (
     siteId: number | string,
-    params?: { nodeId?: string; hostname?: string },
+    params?: { user?: string; nodeId?: string; hostname?: string },
   ) => {
     const qs = new URLSearchParams();
+    // `user` is sent verbatim, including '*' (all owners, admin only) and ''
+    // (own containers). Only omit it when undefined so the default still maps
+    // to the requesting user server-side.
+    if (params?.user !== undefined) qs.set('user', params.user);
     if (params?.nodeId) qs.set('nodeId', params.nodeId);
     if (params?.hostname) qs.set('hostname', params.hostname);
     const suffix = qs.toString() ? `?${qs.toString()}` : '';
-    return api.get<Container[]>(`/api/v1/sites/${siteId}/containers/all${suffix}`);
+    return api.get<Container[]>(`/api/v1/sites/${siteId}/containers${suffix}`);
   },
   getContainer: (siteId: number | string, id: number | string) =>
     api.get<Container>(`/api/v1/sites/${siteId}/containers/${id}`),

--- a/create-a-container/client/src/lib/queries.ts
+++ b/create-a-container/client/src/lib/queries.ts
@@ -27,6 +27,8 @@ export const keys = {
   node: (siteId: number | string, id: number | string) =>
     ['sites', String(siteId), 'nodes', String(id)] as const,
   containers: (siteId: number | string) => ['sites', String(siteId), 'containers'] as const,
+  containersAll: (siteId: number | string, params?: Record<string, string | undefined>) =>
+    ['sites', String(siteId), 'containers', 'all', params ?? {}] as const,
   container: (siteId: number | string, id: number | string) =>
     ['sites', String(siteId), 'containers', String(id)] as const,
   containerBootstrap: (siteId: number | string) =>
@@ -62,6 +64,16 @@ export const queries = {
   // Containers
   listContainers: (siteId: number | string) =>
     api.get<Container[]>(`/api/v1/sites/${siteId}/containers`),
+  listAllContainers: (
+    siteId: number | string,
+    params?: { nodeId?: string; hostname?: string },
+  ) => {
+    const qs = new URLSearchParams();
+    if (params?.nodeId) qs.set('nodeId', params.nodeId);
+    if (params?.hostname) qs.set('hostname', params.hostname);
+    const suffix = qs.toString() ? `?${qs.toString()}` : '';
+    return api.get<Container[]>(`/api/v1/sites/${siteId}/containers/all${suffix}`);
+  },
   getContainer: (siteId: number | string, id: number | string) =>
     api.get<Container>(`/api/v1/sites/${siteId}/containers/${id}`),
   containerBootstrap: (siteId: number | string) =>

--- a/create-a-container/client/src/lib/types.ts
+++ b/create-a-container/client/src/lib/types.ts
@@ -73,6 +73,7 @@ export interface Container {
   id: number;
   containerId: number | null;
   hostname: string;
+  owner: string;
   ipv4Address: string | null;
   macAddress: string | null;
   status: ContainerStatus;

--- a/create-a-container/client/src/pages/containers/ContainersListPage.tsx
+++ b/create-a-container/client/src/pages/containers/ContainersListPage.tsx
@@ -220,12 +220,16 @@ export function ContainersListPage() {
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const nodeId = searchParams.get('nodeId') || undefined;
-  // `user=*` (admin only) lists every owner on the site; anything else falls
-  // back to the requesting user's own containers. The param is the single
-  // source of truth so the view is bookmarkable and slots in beside the
-  // existing hostname/nodeId filters.
+  // `user=*` lists every owner on the site for admins; for non-admins the
+  // server scopes it back to their own containers, so the toggle is available
+  // to everyone (ahead of future shareable/collaborative containers). The param
+  // is the single source of truth so the view is bookmarkable and slots in
+  // beside the existing hostname/nodeId filters.
   const isAll = searchParams.get('user') === '*';
   const userFilter = isAll ? '*' : undefined;
+  // Only admins ever see more than one owner in the `*` view, so the owner
+  // column is meaningful for them alone.
+  const showOwner = isAdmin && isAll;
   const dnsWarnings = (location.state as { dnsWarnings?: string[] } | null)?.dnsWarnings;
 
   const [view, setView] = useState<ViewMode>(() => {
@@ -271,24 +275,22 @@ export function ContainersListPage() {
         icon={<ContainerIcon className="size-6" />}
         actions={
           <div className="flex flex-wrap items-center gap-2">
-            {isAdmin && (
-              <div
-                role="group"
-                aria-label="Container ownership scope"
-                className="inline-flex rounded-md border border-border p-0.5"
-              >
-                <Link to={`/sites/${siteId}/containers`} aria-label="My containers">
-                  <Button variant={isAll ? 'ghost' : 'secondary'} size="sm" aria-pressed={!isAll}>
-                    Mine
-                  </Button>
-                </Link>
-                <Link to={`/sites/${siteId}/containers?user=*`} aria-label="All containers">
-                  <Button variant={isAll ? 'secondary' : 'ghost'} size="sm" aria-pressed={isAll}>
-                    All
-                  </Button>
-                </Link>
-              </div>
-            )}
+            <div
+              role="group"
+              aria-label="Container ownership scope"
+              className="inline-flex rounded-md border border-border p-0.5"
+            >
+              <Link to={`/sites/${siteId}/containers`} aria-label="My containers">
+                <Button variant={isAll ? 'ghost' : 'secondary'} size="sm" aria-pressed={!isAll}>
+                  Mine
+                </Button>
+              </Link>
+              <Link to={`/sites/${siteId}/containers?user=*`} aria-label="All containers">
+                <Button variant={isAll ? 'secondary' : 'ghost'} size="sm" aria-pressed={isAll}>
+                  All
+                </Button>
+              </Link>
+            </div>
             {hasContainers && (
               <div
                 role="group"
@@ -357,7 +359,7 @@ export function ContainersListPage() {
         <Alert variant="info">
           <AlertTitle>No containers</AlertTitle>
           <AlertDescription>
-            {isAll
+            {showOwner
               ? 'No containers exist on this site yet.'
               : 'Create your first container with the button above.'}
           </AlertDescription>
@@ -387,7 +389,7 @@ export function ContainersListPage() {
                 <Meta label="Node">
                   <NodeLink c={c} />
                 </Meta>
-                {isAll && (
+                {showOwner && (
                   <Meta label="User">
                     <span className="inline-flex items-center gap-1">
                       <User className="size-3.5" aria-hidden="true" />
@@ -419,7 +421,7 @@ export function ContainersListPage() {
               <TableHead>Hostname</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Node</TableHead>
-              {isAll && <TableHead>User</TableHead>}
+              {showOwner && <TableHead>User</TableHead>}
               <TableHead>Template</TableHead>
               <TableHead>HTTP</TableHead>
               <TableHead>SSH</TableHead>
@@ -436,7 +438,7 @@ export function ContainersListPage() {
                 <TableCell>
                   <NodeLink c={c} />
                 </TableCell>
-                {isAll && (
+                {showOwner && (
                   <TableCell>
                     <span className="inline-flex items-center gap-1">
                       <User className="size-3.5" aria-hidden="true" />

--- a/create-a-container/client/src/pages/containers/ContainersListPage.tsx
+++ b/create-a-container/client/src/pages/containers/ContainersListPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useLocation, useParams } from 'react-router';
+import { Link, useLocation, useParams, useSearchParams } from 'react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   Alert,
@@ -30,6 +30,7 @@ import {
   Server,
   Terminal,
   Trash2,
+  User,
 } from 'lucide-react';
 import { api, ApiError } from '@/lib/api';
 import { useSession } from '@/lib/auth';
@@ -209,13 +210,17 @@ function Meta({ label, children }: { label: string; children: React.ReactNode })
   );
 }
 
-export function ContainersListPage() {
+export function ContainersListPage({ scope = 'mine' }: { scope?: 'mine' | 'all' }) {
   const { siteId } = useParams<{ siteId: string }>();
   const qc = useQueryClient();
   const toast = useToast();
   const { data: session } = useSession();
   const sessionUser = session?.user;
+  const isAdmin = !!session?.isAdmin;
+  const isAll = scope === 'all';
   const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const nodeId = searchParams.get('nodeId') || undefined;
   const dnsWarnings = (location.state as { dnsWarnings?: string[] } | null)?.dnsWarnings;
 
   const [view, setView] = useState<ViewMode>(() => {
@@ -237,8 +242,9 @@ export function ContainersListPage() {
     enabled: !!siteId,
   });
   const { data, isLoading, error } = useQuery({
-    queryKey: keys.containers(siteId!),
-    queryFn: () => queries.listContainers(siteId!),
+    queryKey: isAll ? keys.containersAll(siteId!, { nodeId }) : keys.containers(siteId!),
+    queryFn: () =>
+      isAll ? queries.listAllContainers(siteId!, { nodeId }) : queries.listContainers(siteId!),
     enabled: !!siteId,
   });
 
@@ -256,11 +262,29 @@ export function ContainersListPage() {
   return (
     <div className="flex flex-col gap-6">
       <PageHeader
-        title="Containers"
+        title={isAll ? 'All Containers' : 'Containers'}
         subtitle={site ? `Site: ${site.name}` : undefined}
         icon={<ContainerIcon className="size-6" />}
         actions={
           <div className="flex flex-wrap items-center gap-2">
+            {isAdmin && (
+              <div
+                role="group"
+                aria-label="Container ownership scope"
+                className="inline-flex rounded-md border border-border p-0.5"
+              >
+                <Link to={`/sites/${siteId}/containers`} aria-label="My containers">
+                  <Button variant={isAll ? 'ghost' : 'secondary'} size="sm" aria-pressed={!isAll}>
+                    Mine
+                  </Button>
+                </Link>
+                <Link to={`/sites/${siteId}/containers/all`} aria-label="All containers">
+                  <Button variant={isAll ? 'secondary' : 'ghost'} size="sm" aria-pressed={isAll}>
+                    All
+                  </Button>
+                </Link>
+              </div>
+            )}
             {hasContainers && (
               <div
                 role="group"
@@ -328,7 +352,11 @@ export function ContainersListPage() {
       {data && data.length === 0 && (
         <Alert variant="info">
           <AlertTitle>No containers</AlertTitle>
-          <AlertDescription>Create your first container with the button above.</AlertDescription>
+          <AlertDescription>
+            {isAll
+              ? 'No containers exist on this site yet.'
+              : 'Create your first container with the button above.'}
+          </AlertDescription>
         </Alert>
       )}
 
@@ -355,6 +383,14 @@ export function ContainersListPage() {
                 <Meta label="Node">
                   <NodeLink c={c} />
                 </Meta>
+                {isAll && (
+                  <Meta label="User">
+                    <span className="inline-flex items-center gap-1">
+                      <User className="size-3.5" aria-hidden="true" />
+                      {c.owner}
+                    </span>
+                  </Meta>
+                )}
                 <Meta label="Template">
                   <span className="font-mono" title={c.template || undefined}>
                     {templateTitle(c.template)}
@@ -379,6 +415,7 @@ export function ContainersListPage() {
               <TableHead>Hostname</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Node</TableHead>
+              {isAll && <TableHead>User</TableHead>}
               <TableHead>Template</TableHead>
               <TableHead>HTTP</TableHead>
               <TableHead>SSH</TableHead>
@@ -395,6 +432,14 @@ export function ContainersListPage() {
                 <TableCell>
                   <NodeLink c={c} />
                 </TableCell>
+                {isAll && (
+                  <TableCell>
+                    <span className="inline-flex items-center gap-1">
+                      <User className="size-3.5" aria-hidden="true" />
+                      {c.owner}
+                    </span>
+                  </TableCell>
+                )}
                 <TableCell className="font-mono text-xs" title={c.template || undefined}>
                   {templateTitle(c.template)}
                 </TableCell>

--- a/create-a-container/client/src/pages/containers/ContainersListPage.tsx
+++ b/create-a-container/client/src/pages/containers/ContainersListPage.tsx
@@ -210,17 +210,22 @@ function Meta({ label, children }: { label: string; children: React.ReactNode })
   );
 }
 
-export function ContainersListPage({ scope = 'mine' }: { scope?: 'mine' | 'all' }) {
+export function ContainersListPage() {
   const { siteId } = useParams<{ siteId: string }>();
   const qc = useQueryClient();
   const toast = useToast();
   const { data: session } = useSession();
   const sessionUser = session?.user;
   const isAdmin = !!session?.isAdmin;
-  const isAll = scope === 'all';
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const nodeId = searchParams.get('nodeId') || undefined;
+  // `user=*` (admin only) lists every owner on the site; anything else falls
+  // back to the requesting user's own containers. The param is the single
+  // source of truth so the view is bookmarkable and slots in beside the
+  // existing hostname/nodeId filters.
+  const isAll = searchParams.get('user') === '*';
+  const userFilter = isAll ? '*' : undefined;
   const dnsWarnings = (location.state as { dnsWarnings?: string[] } | null)?.dnsWarnings;
 
   const [view, setView] = useState<ViewMode>(() => {
@@ -242,9 +247,8 @@ export function ContainersListPage({ scope = 'mine' }: { scope?: 'mine' | 'all' 
     enabled: !!siteId,
   });
   const { data, isLoading, error } = useQuery({
-    queryKey: isAll ? keys.containersAll(siteId!, { nodeId }) : keys.containers(siteId!),
-    queryFn: () =>
-      isAll ? queries.listAllContainers(siteId!, { nodeId }) : queries.listContainers(siteId!),
+    queryKey: keys.containers(siteId!, { user: userFilter, nodeId }),
+    queryFn: () => queries.listContainers(siteId!, { user: userFilter, nodeId }),
     enabled: !!siteId,
   });
 
@@ -278,7 +282,7 @@ export function ContainersListPage({ scope = 'mine' }: { scope?: 'mine' | 'all' 
                     Mine
                   </Button>
                 </Link>
-                <Link to={`/sites/${siteId}/containers/all`} aria-label="All containers">
+                <Link to={`/sites/${siteId}/containers?user=*`} aria-label="All containers">
                   <Button variant={isAll ? 'secondary' : 'ghost'} size="sm" aria-pressed={isAll}>
                     All
                   </Button>

--- a/create-a-container/openapi.v1.yaml
+++ b/create-a-container/openapi.v1.yaml
@@ -312,7 +312,17 @@ paths:
         - { in: path, name: siteId, required: true, schema: { type: integer } }
         - { in: query, name: hostname, schema: { type: string } }
         - { in: query, name: nodeId, schema: { type: integer }, description: Filter to a single node belonging to the site }
-      responses: { '200': { description: Array of containers } }
+        - in: query
+          name: user
+          schema: { type: string }
+          description: >-
+            Owner filter. Omitted/empty returns the requesting user's own
+            containers (default). `*` returns every owner on the site and a
+            specific username returns that owner's containers; both are
+            admin-only and yield 403 for non-admins (except requesting yourself).
+      responses:
+        '200': { description: Array of containers }
+        '403': { description: 'Admin access required', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
     post:
       tags: [Containers]
       parameters: [{ in: path, name: siteId, required: true, schema: { type: integer } }]
@@ -341,22 +351,6 @@ paths:
       summary: Form bootstrap data (domains + NVIDIA flag)
       parameters: [{ in: path, name: siteId, required: true, schema: { type: integer } }]
       responses: { '200': { description: Bootstrap payload } }
-  /sites/{siteId}/containers/all:
-    get:
-      tags: [Containers]
-      summary: List every container on the site (admin only)
-      description: >-
-        Returns all containers belonging to the site regardless of owner. Each
-        container includes the `owner` field. Requires the caller to be an admin;
-        non-admins receive 403.
-      parameters:
-        - { in: path, name: siteId, required: true, schema: { type: integer } }
-        - { in: query, name: hostname, schema: { type: string } }
-        - { in: query, name: nodeId, schema: { type: integer }, description: Filter to a single node belonging to the site }
-        - { in: query, name: username, schema: { type: string }, description: Filter to a single owner }
-      responses:
-        '200': { description: Array of containers }
-        '403': { description: 'Admin access required', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
   /sites/{siteId}/containers/metadata:
     get:
       tags: [Containers]

--- a/create-a-container/openapi.v1.yaml
+++ b/create-a-container/openapi.v1.yaml
@@ -317,9 +317,10 @@ paths:
           schema: { type: string }
           description: >-
             Owner filter. Omitted/empty returns the requesting user's own
-            containers (default). `*` returns every owner on the site and a
-            specific username returns that owner's containers; both are
-            admin-only and yield 403 for non-admins (except requesting yourself).
+            containers (default). `*` returns every owner on the site for admins,
+            or just your own containers for non-admins. A specific username
+            returns that owner's containers and is admin-only (except requesting
+            yourself), yielding 403 otherwise.
       responses:
         '200': { description: Array of containers }
         '403': { description: 'Admin access required', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }

--- a/create-a-container/openapi.v1.yaml
+++ b/create-a-container/openapi.v1.yaml
@@ -88,6 +88,7 @@ components:
       properties:
         id: { type: integer }
         hostname: { type: string }
+        owner: { type: string, description: Username of the user who created the container }
         containerId: { type: integer, nullable: true }
         status: { $ref: '#/components/schemas/ContainerStatus' }
         template: { type: string }
@@ -310,6 +311,7 @@ paths:
       parameters:
         - { in: path, name: siteId, required: true, schema: { type: integer } }
         - { in: query, name: hostname, schema: { type: string } }
+        - { in: query, name: nodeId, schema: { type: integer }, description: Filter to a single node belonging to the site }
       responses: { '200': { description: Array of containers } }
     post:
       tags: [Containers]
@@ -339,6 +341,22 @@ paths:
       summary: Form bootstrap data (domains + NVIDIA flag)
       parameters: [{ in: path, name: siteId, required: true, schema: { type: integer } }]
       responses: { '200': { description: Bootstrap payload } }
+  /sites/{siteId}/containers/all:
+    get:
+      tags: [Containers]
+      summary: List every container on the site (admin only)
+      description: >-
+        Returns all containers belonging to the site regardless of owner. Each
+        container includes the `owner` field. Requires the caller to be an admin;
+        non-admins receive 403.
+      parameters:
+        - { in: path, name: siteId, required: true, schema: { type: integer } }
+        - { in: query, name: hostname, schema: { type: string } }
+        - { in: query, name: nodeId, schema: { type: integer }, description: Filter to a single node belonging to the site }
+        - { in: query, name: username, schema: { type: string }, description: Filter to a single owner }
+      responses:
+        '200': { description: Array of containers }
+        '403': { description: 'Admin access required', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
   /sites/{siteId}/containers/metadata:
     get:
       tags: [Containers]

--- a/create-a-container/routers/api/v1/containers.js
+++ b/create-a-container/routers/api/v1/containers.js
@@ -26,7 +26,7 @@ const {
   computeContainerStatuses,
   STATUS,
 } = require('../../../utils/container-status');
-const { apiAuth, apiAdmin, asyncHandler, ok, created, ApiError } = require('../../../middlewares/api');
+const { apiAuth, asyncHandler, ok, created, ApiError } = require('../../../middlewares/api');
 
 const router = express.Router({ mergeParams: true });
 
@@ -199,6 +199,31 @@ function buildContainerListWhere(query, nodeIds) {
   return where;
 }
 
+/**
+ * Resolve the `user` list filter into a Sequelize `username` constraint,
+ * enforcing authorization. The rules mirror the existing `hostname` filter in
+ * shape (a plain query param) but add ownership scoping:
+ *   - absent/empty -> the requesting user's own containers (default for all)
+ *   - '*'          -> every owner on the site (admin only)
+ *   - '<username>' -> that specific owner (admin only, unless it's yourself)
+ * Non-admins requesting anyone else (or '*') get 403 rather than a silently
+ * empty list, so the boundary is explicit.
+ * @param {string|undefined} requestedUser - req.query.user
+ * @param {{ user: string, isAdmin: boolean }} session - req.session
+ * @returns {string|undefined} username to filter by, or undefined for "all"
+ */
+function resolveUsernameFilter(requestedUser, session) {
+  if (!requestedUser) return session.user;
+  if (requestedUser === '*') {
+    if (!session.isAdmin) throw new ApiError(403, 'forbidden', 'Admin access required');
+    return undefined;
+  }
+  if (requestedUser !== session.user && !session.isAdmin) {
+    throw new ApiError(403, 'forbidden', 'Admin access required');
+  }
+  return requestedUser;
+}
+
 // GET /containers/metadata?image=...
 router.get(
   '/metadata',
@@ -238,30 +263,15 @@ router.get(
     const site = await loadSite(req);
     const nodes = await Node.findAll({ where: { siteId: site.id }, attributes: ['id'] });
     const nodeIds = nodes.map((n) => n.id);
-    const where = { ...buildContainerListWhere(req.query, nodeIds), username: req.session.user };
+    const where = buildContainerListWhere(req.query, nodeIds);
+    // `user` filter: defaults to the requesting user, so everyone (incl. admins)
+    // sees their own containers by default; admins may pass `user=*` for all or
+    // `user=<name>` for a specific owner. undefined means "all owners".
+    const username = resolveUsernameFilter(req.query.user, req.session);
+    if (username !== undefined) where.username = username;
     const rows = await Container.findAll({ where, include: CONTAINER_INCLUDE });
     // Resolve live statuses for the whole page in one pass: one Proxmox snapshot
     // per node (shared), and no per-container DB queries (create job is loaded above).
-    const statuses = await computeContainerStatuses(rows, Job);
-    return ok(
-      res,
-      rows.map((c) => serializeContainer(c, site, statuses.get(c.id))),
-    );
-  }),
-);
-
-// GET /containers/all — admin-only: every container on the site, with owner info.
-// Declared before /:id so the literal "all" segment is not parsed as an id.
-router.get(
-  '/all',
-  apiAdmin,
-  asyncHandler(async (req, res) => {
-    const site = await loadSite(req);
-    const nodes = await Node.findAll({ where: { siteId: site.id }, attributes: ['id'] });
-    const nodeIds = nodes.map((n) => n.id);
-    const where = buildContainerListWhere(req.query, nodeIds);
-    if (req.query.username) where.username = req.query.username;
-    const rows = await Container.findAll({ where, include: CONTAINER_INCLUDE });
     const statuses = await computeContainerStatuses(rows, Job);
     return ok(
       res,

--- a/create-a-container/routers/api/v1/containers.js
+++ b/create-a-container/routers/api/v1/containers.js
@@ -26,7 +26,7 @@ const {
   computeContainerStatuses,
   STATUS,
 } = require('../../../utils/container-status');
-const { apiAuth, asyncHandler, ok, created, ApiError } = require('../../../middlewares/api');
+const { apiAuth, apiAdmin, asyncHandler, ok, created, ApiError } = require('../../../middlewares/api');
 
 const router = express.Router({ mergeParams: true });
 
@@ -113,6 +113,10 @@ function serializeContainer(c, site, status) {
     id: c.id,
     containerId: c.containerId,
     hostname: c.hostname,
+    // Owner (the user who created the container). Surfaced so the admin
+    // "all containers" view can show a User column; for the per-user list it
+    // simply equals the requesting user.
+    owner: c.username,
     ipv4Address: c.ipv4Address,
     macAddress: c.macAddress,
     // Live status computed from Proxmox + jobs + config (see utils/container-status).
@@ -157,6 +161,44 @@ function serializeContainer(c, site, status) {
   };
 }
 
+// Eager-load graph shared by every list/show route so status resolution needs
+// no per-container queries and the serializer has the data it needs.
+const CONTAINER_INCLUDE = [
+  {
+    association: 'services',
+    include: [
+      { association: 'httpService', include: [{ association: 'externalDomain' }] },
+      { association: 'transportService' },
+      { association: 'dnsService' },
+    ],
+  },
+  // Full node record (incl. credentials) is required to query live Proxmox status.
+  { association: 'node' },
+  // Eager-load the create job so status resolution needs no per-container query.
+  { association: 'creationJob' },
+];
+
+/**
+ * Build the `where` clause for a container list query, scoped to the given
+ * site's nodes and narrowed by the supported query-string filters
+ * (`hostname`, `nodeId`). The `nodeId` filter is intersected with the site's
+ * own nodes so it can never widen the result set beyond the site.
+ * @param {object} query - req.query
+ * @param {number[]} nodeIds - IDs of the nodes belonging to the site
+ * @returns {object} Sequelize where clause
+ */
+function buildContainerListWhere(query, nodeIds) {
+  const where = { nodeId: nodeIds };
+  if (query.hostname) where.hostname = query.hostname;
+  if (query.nodeId) {
+    const nodeId = parseInt(query.nodeId, 10);
+    // Restrict to the requested node only when it belongs to this site;
+    // otherwise force an empty result rather than leaking other sites' nodes.
+    where.nodeId = Number.isInteger(nodeId) && nodeIds.includes(nodeId) ? nodeId : -1;
+  }
+  return where;
+}
+
 // GET /containers/metadata?image=...
 router.get(
   '/metadata',
@@ -196,27 +238,30 @@ router.get(
     const site = await loadSite(req);
     const nodes = await Node.findAll({ where: { siteId: site.id }, attributes: ['id'] });
     const nodeIds = nodes.map((n) => n.id);
-    const where = { username: req.session.user, nodeId: nodeIds };
-    if (req.query.hostname) where.hostname = req.query.hostname;
-    const rows = await Container.findAll({
-      where,
-      include: [
-        {
-          association: 'services',
-          include: [
-            { association: 'httpService', include: [{ association: 'externalDomain' }] },
-            { association: 'transportService' },
-            { association: 'dnsService' },
-          ],
-        },
-        // Full node record (incl. credentials) is required to query live Proxmox status.
-        { association: 'node' },
-        // Eager-load the create job so status resolution needs no per-container query.
-        { association: 'creationJob' },
-      ],
-    });
+    const where = { ...buildContainerListWhere(req.query, nodeIds), username: req.session.user };
+    const rows = await Container.findAll({ where, include: CONTAINER_INCLUDE });
     // Resolve live statuses for the whole page in one pass: one Proxmox snapshot
     // per node (shared), and no per-container DB queries (create job is loaded above).
+    const statuses = await computeContainerStatuses(rows, Job);
+    return ok(
+      res,
+      rows.map((c) => serializeContainer(c, site, statuses.get(c.id))),
+    );
+  }),
+);
+
+// GET /containers/all — admin-only: every container on the site, with owner info.
+// Declared before /:id so the literal "all" segment is not parsed as an id.
+router.get(
+  '/all',
+  apiAdmin,
+  asyncHandler(async (req, res) => {
+    const site = await loadSite(req);
+    const nodes = await Node.findAll({ where: { siteId: site.id }, attributes: ['id'] });
+    const nodeIds = nodes.map((n) => n.id);
+    const where = buildContainerListWhere(req.query, nodeIds);
+    if (req.query.username) where.username = req.query.username;
+    const rows = await Container.findAll({ where, include: CONTAINER_INCLUDE });
     const statuses = await computeContainerStatuses(rows, Job);
     return ok(
       res,
@@ -239,18 +284,7 @@ router.get(
     }
     const c = await Container.findOne({
       where: { id: containerId, username: req.session.user },
-      include: [
-        {
-          association: 'services',
-          include: [
-            { association: 'httpService', include: [{ association: 'externalDomain' }] },
-            { association: 'transportService' },
-            { association: 'dnsService' },
-          ],
-        },
-        { association: 'node' },
-        { association: 'creationJob' },
-      ],
+      include: CONTAINER_INCLUDE,
     });
     if (!c || !c.node || c.node.siteId !== site.id) {
       throw new ApiError(404, 'not_found', 'Container not found');

--- a/create-a-container/routers/api/v1/containers.js
+++ b/create-a-container/routers/api/v1/containers.js
@@ -204,10 +204,12 @@ function buildContainerListWhere(query, nodeIds) {
  * enforcing authorization. The rules mirror the existing `hostname` filter in
  * shape (a plain query param) but add ownership scoping:
  *   - absent/empty -> the requesting user's own containers (default for all)
- *   - '*'          -> every owner on the site (admin only)
+ *   - '*'          -> every owner on the site (admin), or just your own (non-admin)
  *   - '<username>' -> that specific owner (admin only, unless it's yourself)
- * Non-admins requesting anyone else (or '*') get 403 rather than a silently
- * empty list, so the boundary is explicit.
+ * Non-admins may use `*`, but it is scoped to their own containers rather than
+ * returning a 403. This keeps the "All" toggle usable for everyone today and
+ * leaves room for future shareable/collaborative containers to widen what a
+ * non-admin sees here. Requesting a specific *other* owner still 403s.
  * @param {string|undefined} requestedUser - req.query.user
  * @param {{ user: string, isAdmin: boolean }} session - req.session
  * @returns {string|undefined} username to filter by, or undefined for "all"
@@ -215,8 +217,8 @@ function buildContainerListWhere(query, nodeIds) {
 function resolveUsernameFilter(requestedUser, session) {
   if (!requestedUser) return session.user;
   if (requestedUser === '*') {
-    if (!session.isAdmin) throw new ApiError(403, 'forbidden', 'Admin access required');
-    return undefined;
+    // Admins see every owner; non-admins are scoped to their own containers.
+    return session.isAdmin ? undefined : session.user;
   }
   if (requestedUser !== session.user && !session.isAdmin) {
     throw new ApiError(403, 'forbidden', 'Admin access required');
@@ -265,8 +267,9 @@ router.get(
     const nodeIds = nodes.map((n) => n.id);
     const where = buildContainerListWhere(req.query, nodeIds);
     // `user` filter: defaults to the requesting user, so everyone (incl. admins)
-    // sees their own containers by default; admins may pass `user=*` for all or
-    // `user=<name>` for a specific owner. undefined means "all owners".
+    // sees their own containers by default. `user=*` lists every owner for admins
+    // and stays scoped to the requester for non-admins; `user=<name>` targets a
+    // specific owner (admin-only). undefined means "all owners".
     const username = resolveUsernameFilter(req.query.user, req.session);
     if (username !== undefined) where.username = username;
     const rows = await Container.findAll({ where, include: CONTAINER_INCLUDE });

--- a/images/proxmox-ve/create-manager.sh
+++ b/images/proxmox-ve/create-manager.sh
@@ -11,9 +11,23 @@ until [ -d /etc/pve/local ]; do
     sleep 0.5
 done
 
-# Exit success if the specified container already exists
-if [ -f "/etc/pve/lxc/${CTID}.conf" ]; then
-    exit 0
+# Decide whether the container is already fully provisioned. A bare existence
+# check on the config file is not enough: an interrupted prior `pct create`
+# (common under the nested Proxmox-in-Docker, e.g. a failed `--start=1`) leaves
+# a partial config behind that is still holding the `create` lock and missing
+# required keys like `arch`. Treating that half-created container as "done"
+# wedges every subsequent boot (`pct start` then fails with "missing 'arch'").
+# So only short-circuit when the config exists, carries no lingering create
+# lock, and has a real `arch` line; otherwise tear the remnants down and rebuild.
+CONF="/etc/pve/lxc/${CTID}.conf"
+if [ -f "${CONF}" ]; then
+    if ! grep -q '^lock: create' "${CONF}" && grep -q '^arch:' "${CONF}"; then
+        exit 0
+    fi
+    echo "Container ${CTID} is partially created; tearing it down and recreating."
+    pct unlock "${CTID}" || true
+    pct stop "${CTID}" || true
+    pct destroy "${CTID}" --force || true
 fi
 
 # Ensure the specified network are available

--- a/images/proxmox-ve/create-manager.sh
+++ b/images/proxmox-ve/create-manager.sh
@@ -14,14 +14,14 @@ done
 # Decide whether the container is already fully provisioned. A bare existence
 # check on the config file is not enough: an interrupted prior `pct create`
 # (common under the nested Proxmox-in-Docker, e.g. a failed `--start=1`) leaves
-# a partial config behind that is still holding the `create` lock and missing
-# required keys like `arch`. Treating that half-created container as "done"
-# wedges every subsequent boot (`pct start` then fails with "missing 'arch'").
-# So only short-circuit when the config exists, carries no lingering create
-# lock, and has a real `arch` line; otherwise tear the remnants down and rebuild.
+# a partial config behind that is still holding the `create` lock. Treating that
+# half-created container as "done" wedges every subsequent boot (`pct start`
+# then fails with "missing 'arch'"). `pct create` releases the lock only on
+# success, so its absence reliably marks a complete container; if the lock is
+# still present we tear the remnants down and rebuild.
 CONF="/etc/pve/lxc/${CTID}.conf"
 if [ -f "${CONF}" ]; then
-    if ! grep -q '^lock: create' "${CONF}" && grep -q '^arch:' "${CONF}"; then
+    if ! grep -q '^lock: create' "${CONF}"; then
         exit 0
     fi
     echo "Container ${CTID} is partially created; tearing it down and recreating."

--- a/images/proxmox-ve/create-manager.sh
+++ b/images/proxmox-ve/create-manager.sh
@@ -25,9 +25,8 @@ if [ -f "${CONF}" ]; then
         exit 0
     fi
     echo "Container ${CTID} is partially created; tearing it down and recreating."
-    pct unlock "${CTID}" || true
-    pct stop "${CTID}" || true
-    pct destroy "${CTID}" --force || true
+    pct unlock "${CTID}"
+    pct destroy "${CTID}" --force
 fi
 
 # Ensure the specified network are available


### PR DESCRIPTION
Issue: https://github.com/mieweb/opensource-server/pull/374

This pull request introduces an "All Containers" admin view to the container management system, allowing admins to see every container on a site, including the owner of each container. It also refactors the Docker Compose setup to prevent race conditions during dependency installation, and extends the API, client types, and OpenAPI schema to support the new functionality.

**Admin "All Containers" View and API Enhancements:**

* Added a new `/sites/{siteId}/containers/all` API endpoint (admin-only) that returns all containers for a site, including the `owner` field, with support for filtering by `nodeId`, `hostname`, and `username`. [[1]](diffhunk://#diff-bdedb7b5057f4a7c805abbe4ef41948dd186af96f25737d1c806c2c97ba31151R344-R359) [[2]](diffhunk://#diff-44647bcd3b853c60c4948db454e8deec1dd1e5aa05f1dbdf4e42ef9daa2e0f22R253-R272) [[3]](diffhunk://#diff-44647bcd3b853c60c4948db454e8deec1dd1e5aa05f1dbdf4e42ef9daa2e0f22R116-R119) [[4]](diffhunk://#diff-44647bcd3b853c60c4948db454e8deec1dd1e5aa05f1dbdf4e42ef9daa2e0f22R164-R201)
* Updated the OpenAPI schema to document the new endpoint, the `owner` field on containers, and the new query parameters. [[1]](diffhunk://#diff-bdedb7b5057f4a7c805abbe4ef41948dd186af96f25737d1c806c2c97ba31151R91) [[2]](diffhunk://#diff-bdedb7b5057f4a7c805abbe4ef41948dd186af96f25737d1c806c2c97ba31151R314) [[3]](diffhunk://#diff-bdedb7b5057f4a7c805abbe4ef41948dd186af96f25737d1c806c2c97ba31151R344-R359)
* Updated the backend container serialization and query logic to include the `owner` field and to support flexible filtering for both user and admin list endpoints. [[1]](diffhunk://#diff-44647bcd3b853c60c4948db454e8deec1dd1e5aa05f1dbdf4e42ef9daa2e0f22R116-R119) [[2]](diffhunk://#diff-44647bcd3b853c60c4948db454e8deec1dd1e5aa05f1dbdf4e42ef9daa2e0f22L199-R242) [[3]](diffhunk://#diff-44647bcd3b853c60c4948db454e8deec1dd1e5aa05f1dbdf4e42ef9daa2e0f22R164-R201) [[4]](diffhunk://#diff-44647bcd3b853c60c4948db454e8deec1dd1e5aa05f1dbdf4e42ef9daa2e0f22R253-R272)

**Frontend: Containers List Page and API Integration:**

* Enhanced the `ContainersListPage` to support an "all"/"mine" toggle (visible to admins), display the container owner in the "All" view, and handle new query parameters for filtering. [[1]](diffhunk://#diff-65e8c60e95f1cfe5f50137f11eb75479913707599687553c516efc586e85120aR56) [[2]](diffhunk://#diff-8738a2103e2d5a44bda30689de14774ed7a0cb19be5bf96eae5af57b973cf5afL212-R223) [[3]](diffhunk://#diff-8738a2103e2d5a44bda30689de14774ed7a0cb19be5bf96eae5af57b973cf5afL240-R247) [[4]](diffhunk://#diff-8738a2103e2d5a44bda30689de14774ed7a0cb19be5bf96eae5af57b973cf5afL259-R287) [[5]](diffhunk://#diff-8738a2103e2d5a44bda30689de14774ed7a0cb19be5bf96eae5af57b973cf5afL331-R359) [[6]](diffhunk://#diff-8738a2103e2d5a44bda30689de14774ed7a0cb19be5bf96eae5af57b973cf5afR386-R393) [[7]](diffhunk://#diff-8738a2103e2d5a44bda30689de14774ed7a0cb19be5bf96eae5af57b973cf5afR418) [[8]](diffhunk://#diff-8738a2103e2d5a44bda30689de14774ed7a0cb19be5bf96eae5af57b973cf5afR435-R442)
* Updated client-side types and queries to handle the `owner` field and the new `listAllContainers` API. [[1]](diffhunk://#diff-36c13c4ddc6c36d2b82650e648811a2098216150795ca8a0d4973b5ea6a1716aR76) [[2]](diffhunk://#diff-3ec7271b4d8a874c93fe3877afeab9bc537844a6e1ecc0703884d0257f2e7b82R30-R31) [[3]](diffhunk://#diff-3ec7271b4d8a874c93fe3877afeab9bc537844a6e1ecc0703884d0257f2e7b82R67-R76)

**Docker Compose Dependency Installation Improvements:**

* Refactored the Docker Compose setup so only the `node` service runs `npm ci` (with `--ignore-scripts` and manual patching), preventing race conditions and ensuring reliable dependency setup for both server and client. The `client` service now waits for `node` to finish before building. [[1]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R35-R52) [[2]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L43-R62) [[3]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R82-R92)

<img width="2552" height="513" alt="image" src="https://github.com/user-attachments/assets/31ce18d0-8c39-40b3-9034-7278fc294397" />
<img width="2412" height="481" alt="image" src="https://github.com/user-attachments/assets/0becdcf3-4f57-47de-a42a-eb36074a4ef4" />
<img width="2449" height="495" alt="image" src="https://github.com/user-attachments/assets/976c48be-bd9d-4a41-a861-e2cd97f48d9d" />
<img width="2443" height="369" alt="image" src="https://github.com/user-attachments/assets/41a5dbb6-966e-4e27-b088-b532f6d12372" />
