### PR TITLE
docs: rename Developers nav to Contributors and add scope warning

### DIFF
--- a/create-a-container/.gitignore
+++ b/create-a-container/.gitignore
@@ -2,6 +2,10 @@
 node_modules
 data/
 
+# test artifacts
+playwright-report/
+test-results/
+
 # packaging build artifacts
 /.pkg/
 /*.deb

--- a/mie-opensource-landing/docs/developers/contributing.md
+++ b/mie-opensource-landing/docs/developers/contributing.md
@@ -1,6 +1,8 @@
 
 # Contributing
 
+{{ contributor_warning }}
+
 ## Getting Started
 
 1. Review the [GitHub repository](https://github.com/mieweb/opensource-server) and open issues

--- a/mie-opensource-landing/docs/developers/core-technologies.md
+++ b/mie-opensource-landing/docs/developers/core-technologies.md
@@ -1,6 +1,8 @@
 
 # Core Technologies
 
+{{ contributor_warning }}
+
 External documentation for core components.
 
 | Component | Links |

--- a/mie-opensource-landing/docs/developers/database-schema.md
+++ b/mie-opensource-landing/docs/developers/database-schema.md
@@ -1,6 +1,8 @@
 
 # Database Schema
 
+{{ contributor_warning }}
+
 The cluster management system uses Sequelize ORM with PostgreSQL. While Sequelize supports other databases, only PostgreSQL is officially supported.
 
 ## Entity Relationship Diagram

--- a/mie-opensource-landing/docs/developers/development-workflow.md
+++ b/mie-opensource-landing/docs/developers/development-workflow.md
@@ -1,5 +1,7 @@
 # Development Workflow
 
+{{ contributor_warning }}
+
 There are two ways to run the Manager locally:
 
 - **`make dev`** — a lightweight, Proxmox-free workflow for iterating on the

--- a/mie-opensource-landing/docs/developers/docker-images.md
+++ b/mie-opensource-landing/docs/developers/docker-images.md
@@ -1,6 +1,8 @@
 
 # Docker Images
 
+{{ contributor_warning }}
+
 OCI container images automatically built and published to GitHub Container Registry (GHCR). Used as base templates for Proxmox containers.
 
 ## Available Images

--- a/mie-opensource-landing/docs/developers/pull-config.md
+++ b/mie-opensource-landing/docs/developers/pull-config.md
@@ -1,6 +1,8 @@
 
 # pull-config
 
+{{ contributor_warning }}
+
 Cron-based configuration management that pulls config files from the manager API. Installed on agent and manager containers. For deployment instructions, see [Deploying Agents](../admins/deploying-agents.md).
 
 ## Architecture

--- a/mie-opensource-landing/docs/developers/release-pipeline.md
+++ b/mie-opensource-landing/docs/developers/release-pipeline.md
@@ -1,5 +1,7 @@
 # Release Pipeline
 
+{{ contributor_warning }}
+
 The three deployable components are packaged as Debian packages and published
 to GitHub Releases as a flat APT repository. The same component build commands
 are reused by local development, the container images, and CI.

--- a/mie-opensource-landing/docs/developers/system-architecture.md
+++ b/mie-opensource-landing/docs/developers/system-architecture.md
@@ -1,6 +1,8 @@
 
 # System Architecture
 
+{{ contributor_warning }}
+
 ## Overview
 
 ```mermaid

--- a/mie-opensource-landing/main.py
+++ b/mie-opensource-landing/main.py
@@ -6,6 +6,7 @@ can reference deployment-specific endpoints without hard-coding hostnames.
 Variables:
     proxmox_url  — Proxmox web UI base URL (env: PROXMOX_URL)
     manager_url  — Manager web UI base URL (env: MANAGER_URL)
+    contributor_warning  — Shared admonition shown on every contributor page
 """
 
 from __future__ import annotations
@@ -15,7 +16,16 @@ import os
 DEFAULT_PROXMOX_URL = "https://os.mieweb.org:8006"
 DEFAULT_MANAGER_URL = "https://manager.os.mieweb.org"
 
+CONTRIBUTOR_WARNING = (
+    '!!! warning "Contributor documentation"\n'
+    "    This section explains how the Manager, Nodes, and cluster work "
+    "internally and how to contribute to the opensource cluster itself. If you "
+    "are a developer who just wants to run your own code on the cluster, see the "
+    "[Users documentation](../users/getting-started.md) instead."
+)
+
 
 def define_env(env) -> None:
     env.variables["proxmox_url"] = os.environ.get("PROXMOX_URL", DEFAULT_PROXMOX_URL)
     env.variables["manager_url"] = os.environ.get("MANAGER_URL", DEFAULT_MANAGER_URL)
+    env.variables["contributor_warning"] = CONTRIBUTOR_WARNING

--- a/mie-opensource-landing/zensical.toml
+++ b/mie-opensource-landing/zensical.toml
@@ -46,7 +46,7 @@ nav = [
       { "Kernel Keyring" = "admins/kernel-keyring.md" },
       { "NVIDIA Container Toolkit" = "admins/nvidia-container-toolkit.md" },
     ] },
-    { "Developers" = [
+    { "Contributors" = [
       { "System Architecture" = "developers/system-architecture.md" },
       { "Core Technologies" = "developers/core-technologies.md" },
       { "Development Workflow" = "developers/development-workflow.md" },


### PR DESCRIPTION
## Summary

- Renamed the **Developers** nav menu to **Contributors** in `zensical.toml`.
- Added a warning admonition to every page in the section clarifying it documents how the **Manager, Nodes, and cluster** work internally and how to contribute to the opensource cluster.
- The warning directs developers who just want to run their own code on the cluster to the **Users** documentation instead.

## DRY

The warning text is defined once as a `contributor_warning` macro in `main.py` (matching the existing `proxmox_url`/`manager_url` pattern) and referenced via `{{ contributor_warning }}` on each page, so edits happen in one place.

## Housekeeping

- Added `playwright-report/` and `test-results/` to `create-a-container/.gitignore`.