### PR TITLE
feat(manager): add Proxmox cluster link to Containers page

### DIFF
--- a/create-a-container/client/src/pages/containers/ContainersListPage.tsx
+++ b/create-a-container/client/src/pages/containers/ContainersListPage.tsx
@@ -253,6 +253,19 @@ export function ContainersListPage() {
 
   const hasContainers = !!data && data.length > 0;
 
+  // The Proxmox cluster web UI lives at the origin of any node's API URL
+  // (e.g. https://os.mieweb.org:8006). Derive it from the container list so we
+  // never hardcode a cluster host.
+  const proxmoxClusterUrl = (() => {
+    const apiUrl = data?.find((c) => c.nodeApiUrl)?.nodeApiUrl;
+    if (!apiUrl) return null;
+    try {
+      return new URL(apiUrl).origin;
+    } catch {
+      return null;
+    }
+  })();
+
   return (
     <div className="flex flex-col gap-6">
       <PageHeader
@@ -294,6 +307,17 @@ export function ContainersListPage() {
                 <span className="hidden sm:inline">Nodes</span>
               </Button>
             </Link>
+            {proxmoxClusterUrl && (
+              <a href={proxmoxClusterUrl} target="_blank" rel="noopener noreferrer">
+                <Button
+                  variant="ghost"
+                  aria-label="Open Proxmox cluster web UI"
+                  leftIcon={<ExternalLink className="size-4" />}
+                >
+                  <span className="hidden sm:inline">Proxmox</span>
+                </Button>
+              </a>
+            )}
             <Link to={`/sites/${siteId}/containers/new`}>
               <Button variant="primary" aria-label="New container" leftIcon={<Plus className="size-4" />}>
                 <span className="hidden sm:inline">New container</span>


### PR DESCRIPTION

## Summary

Adds a **Proxmox** button to the Containers page header (`/sites/:siteId/containers`) that opens the Proxmox cluster web UI (e.g. https://os.mieweb.org:8006) in a new tab.

<img width="600"  alt="Screenshot 2026-06-24 at 7 37 54 AM" src="https://github.com/user-attachments/assets/c9194176-18d3-478a-85da-c0eb663f5a0a" />

<img width="400"  alt="image" src="https://github.com/user-attachments/assets/55735213-d900-4f0f-9246-bdd7c0fda588" />


## Details

- The button sits between **Nodes** and **New container** in the page header.
- The cluster URL is **derived from the origin of a node's API URL** in the container list, so no cluster host is hardcoded — it adapts to any deployment.
- The button only renders when a node API URL is available (`new URL(apiUrl).origin`), and silently hides if none can be parsed.
- Opens in a new tab with `rel="noopener noreferrer"` and an accessible `aria-label` ("Open Proxmox cluster web UI").

## Testing

Verified locally via `make dev`: the button renders in the header and links to the cluster origin.