### PR TITLE
Fix #307: pin sshd LoginGraceTime to cover the 2FA push window

### DIFF
--- a/images/base/50-login-grace-time.conf
+++ b/images/base/50-login-grace-time.conf
@@ -1,0 +1,7 @@
+# Give SSH logins enough time to answer the push-notification 2FA prompt.
+# Authentication flows through sssd -> the LDAP gateway, which allows up to
+# 60s for a push to be responded to (see ldap_opt_timeout in sssd.conf.template).
+# sshd's default LoginGraceTime can cut the connection before that window
+# closes, so pin it above the 60s 2FA timeout, leaving headroom for the TCP
+# and key-exchange handshake that precedes the LDAP bind. See issue #307.
+LoginGraceTime 75

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && \
 COPY --chmod=0440 sssd.conf.template /etc/sssd/sssd.conf.template
 COPY --chmod=0440 50-sssd-conf-template.conf /etc/systemd/system/sssd.service.d/50-sssd-conf-template.conf
 COPY --chmod=0644 50-sss-ssh-authorizedkeys.conf /etc/ssh/sshd_config.d/50-sss-ssh-authorizedkeys.conf
+COPY --chmod=0644 50-login-grace-time.conf /etc/ssh/sshd_config.d/50-login-grace-time.conf
 COPY --chmod=0440 ldapusers /etc/sudoers.d/ldapusers
 COPY --chmod=0644 ldap.conf /etc/ldap/ldap.conf
 COPY --chmod=0755 git-identity.sh /etc/profile.d/git-identity.sh


### PR DESCRIPTION
## Issue

Fixes #307 — *SSH Timeout too short.* The SSH login window can be shorter than the 2FA timeout, so a user who answers the push in time still gets disconnected.

## Root cause (my reading — please confirm)

SSH logins into a container authenticate through `sssd` → the LDAP gateway, which fires a push‑notification 2FA. The sssd side already allows up to **60s** for the push to be answered:

```
# images/base/sssd.conf.template
# set a timeout long enough for a push notification to be responded to
ldap_opt_timeout = 60
```

But the container's sshd has no matching `LoginGraceTime`, so sshd's default grace window can drop the connection before that 60s push window closes.

## Change

Add a dedicated `sshd_config.d` drop-in setting `LoginGraceTime 75` and copy it into the base image. 75s sits just above the 60s 2FA timeout, leaving headroom for the TCP + key-exchange handshake that precedes the LDAP bind.

- `images/base/50-login-grace-time.conf` (new)
- `images/base/Dockerfile` — copy the drop-in into `/etc/ssh/sshd_config.d/`

Follows the existing drop-in pattern (`50-sss-ssh-authorizedkeys.conf`) and keeps the change config-only.

## Notes / open question

The issue is terse, so I inferred the mechanism from the code rather than a live repro. If the intended value is exactly **60s** (matching the issue text) rather than 75s with headroom, I'm happy to change it. And if the real timeout lives somewhere other than the container's sshd (e.g. a gateway/proxy in front), point me at it and I'll move the fix.