### PR TITLE
Display auto-assigned external port for TCP/UDP services

### DIFF
--- a/create-a-container/client/src/pages/containers/ContainerFormPage.tsx
+++ b/create-a-container/client/src/pages/containers/ContainerFormPage.tsx
@@ -52,6 +52,7 @@ const serviceSchema = z
     id: z.number().optional(),
     type: z.enum(['http', 'https', 'tcp', 'udp', 'srv']),
     internalPort: z.string(),
+    externalPort: z.number().optional(),
     externalHostname: z.string().optional(),
     externalDomainId: z.string().optional(),
     dnsName: z.string().optional(),
@@ -183,6 +184,7 @@ export function ContainerFormPage() {
                   : 'http'
                 : (s.transportService?.protocol ?? 'tcp'),
           internalPort: String(s.internalPort),
+          externalPort: s.transportService?.externalPort,
           externalHostname: s.httpService?.externalHostname || '',
           externalDomainId: s.httpService ? String(s.httpService.externalDomainId) : '',
           dnsName: s.dnsService?.dnsName || '',
@@ -625,6 +627,20 @@ export function ContainerFormPage() {
                           setValue(`services.${idx}.authRequired`, c)
                         }
                       />
+                    </div>
+                  )}
+                  {(svc.type === 'tcp' || svc.type === 'udp') && (
+                    <div>
+                      <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                        External port
+                      </p>
+                      <p className="font-mono text-sm">
+                        {svc.externalPort ?? (
+                          <span className="text-muted-foreground">
+                            Auto-assigned on save
+                          </span>
+                        )}
+                      </p>
                     </div>
                   )}
                   {svc.type === 'srv' && (


### PR DESCRIPTION
Part of #360 (split out for a small, self-contained review).

## What
TCP/UDP transport services get an auto-assigned external port. The value is already stored and serialized by the API, but it was never shown in the UI. This surfaces it (read-only) in each TCP/UDP service row of the container form. New, unsaved services show "Auto-assigned on save".

## Scope
Frontend only — a single change to `ContainerFormPage.tsx`:
- add `externalPort` to the service form schema,
- populate it from `transportService.externalPort` when editing,
- render a read-only "External port" line for `tcp`/`udp` services.

No backend, model, migration, or API changes.

## Notes
- The rest of the TLS work (termination, the TLS service type, in-place service editing, docs, OpenAPI) is stacked on top in #365.
- Verified: client `tsc -b --noEmit` and `vite build` pass.