### PR TITLE
Add 'Site' column to resource requests table

### DIFF
--- a/create-a-container/client/src/pages/resource-requests/ResourceRequestsPage.tsx
+++ b/create-a-container/client/src/pages/resource-requests/ResourceRequestsPage.tsx
@@ -122,6 +122,7 @@ export function ResourceRequestsPage() {
                   <table className="w-full text-sm" role="table" aria-label="Pending resource requests">
                     <thead>
                       <tr className="border-b border-border bg-muted/20">
+                        <th className="w-36 px-5 py-3.5 text-left font-medium">Site</th>
                         <th className="w-40 px-5 py-3.5 text-left font-medium">Container</th>
                         <th className="w-36 px-5 py-3.5 text-left font-medium">User</th>
                         <th className="w-32 px-5 py-3.5 text-left font-medium">Resource</th>


### PR DESCRIPTION
Insert a new "Site" <th> into the Pending resource requests table in ResourceRequestsPage. The new column uses existing table cell classes (w-36, px-5, py-3.5) and is placed before the Container column to show site information for each request.

**Before:** 
<img width="1387" height="502" alt="image" src="https://github.com/user-attachments/assets/6d9fdae6-2453-4eb2-aca0-785efe5db066" />

**After:**
<img width="1413" height="388" alt="image" src="https://github.com/user-attachments/assets/9426e2c0-c15d-46a3-8e51-c9ac3058ffaf" />
