### PR TITLE
fix(cleanup-preview): use correct secrets names

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -175,5 +175,5 @@ jobs:
       - name: Remove preview container
         uses: mieweb/launchpad@main
         with:
-          api_key: ${{ secrets.LAUNCHPAD_API_KEY }}
-          api_url: ${{ secrets.LAUNCHPAD_API_URL }}
+          api_key: ${{ secrets.API_KEY }}
+          api_url: ${{ secrets.API_URL }}


### PR DESCRIPTION
# Copilot Summay

This pull request makes a small update to the workflow configuration by changing the secret names used for the `api_key` and `api_url` in the `.github/workflows/build-images.yml` file to use more generic environment variable names.