### PR TITLE
feat(authentik): route database connections through PgBouncer

### DIFF
--- a/authentik/README.md
+++ b/authentik/README.md
@@ -15,7 +15,7 @@ notification service" refers to that provider.
 
 | Path | Purpose |
 |---|---|
-| `compose.yml` | Server + worker + PostgreSQL services |
+| `compose.yml` | Server + worker + PostgreSQL + PgBouncer services |
 | `blueprints/` | Declarative flows, stages, providers, and applications |
 | `certs/` | LDAPS / outpost certificates (git-ignored) |
 | `custom-templates/` | Email and flow template overrides (git-ignored) |

--- a/authentik/compose.yml
+++ b/authentik/compose.yml
@@ -18,6 +18,23 @@ services:
         - CMD-SHELL
         - pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}
       timeout: 5s
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    environment:
+      DB_HOST: postgresql
+      DB_PORT: 5432
+      DB_USER: ${PG_USER:-authentik}
+      DB_PASSWORD: ${PG_PASS:?database password required}
+      DB_NAME: ${PG_DB:-authentik}
+      POOL_MODE: transaction
+      MAX_CLIENT_CONN: 500
+      DEFAULT_POOL_SIZE: 20
+      AUTH_TYPE: scram-sha-256
+      AUTH_QUERY: SELECT usename, passwd FROM pg_shadow WHERE usename=$$1
+    restart: unless-stopped
   server:
     image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2026.5.2}
     depends_on:
@@ -28,10 +45,11 @@ services:
       - ./custom-templates:/templates
       - /etc/ssl/certs/ca-certificates.crt:/ak-root/.venv/lib/python3.14/site-packages/duo_client/ca_certs.pem
     environment:
-      AUTHENTIK_POSTGRESQL__HOST: postgresql
+      AUTHENTIK_POSTGRESQL__HOST: pgbouncer
       AUTHENTIK_POSTGRESQL__NAME: ${PG_DB:-authentik}
       AUTHENTIK_POSTGRESQL__PASSWORD: ${PG_PASS}
       AUTHENTIK_POSTGRESQL__USER: ${PG_USER:-authentik}
+      AUTHENTIK_POSTGRESQL__DISABLE_SERVER_SIDE_CURSORS: 'true'
       AUTHENTIK_SECRET_KEY: ${AUTHENTIK_SECRET_KEY:?secret key required}
     env_file:
       - .env
@@ -52,10 +70,11 @@ services:
       - ./certs:/certs
       - ./custom-templates:/templates
     environment:
-      AUTHENTIK_POSTGRESQL__HOST: postgresql
+      AUTHENTIK_POSTGRESQL__HOST: pgbouncer
       AUTHENTIK_POSTGRESQL__NAME: ${PG_DB:-authentik}
       AUTHENTIK_POSTGRESQL__PASSWORD: ${PG_PASS}
       AUTHENTIK_POSTGRESQL__USER: ${PG_USER:-authentik}
+      AUTHENTIK_POSTGRESQL__DISABLE_SERVER_SIDE_CURSORS: 'true'
       AUTHENTIK_SECRET_KEY: ${AUTHENTIK_SECRET_KEY:?secret key required}
     env_file:
       - .env

--- a/authentik/compose.yml
+++ b/authentik/compose.yml
@@ -36,7 +36,7 @@ services:
       AUTH_QUERY: SELECT usename, passwd FROM pg_shadow WHERE usename=$$1
     restart: unless-stopped
   server:
-    image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2026.5.2}
+    image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2026.5.4}
     depends_on:
       postgresql:
         condition: service_healthy
@@ -60,7 +60,7 @@ services:
     restart: unless-stopped
     shm_size: 512mb
   worker:
-    image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2026.5.2}
+    image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2026.5.4}
     depends_on:
       postgresql:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Adds a PgBouncer connection pooler between authentik and PostgreSQL, and bumps the default authentik image tag to 2026.5.4 (separate commit).

This mirrors what is already deployed and running in production.

## Changes

### PgBouncer (`5a6f7bd`)
- New `pgbouncer` service (`edoburu/pgbouncer:latest`) in `authentik/compose.yml`:
  - **Transaction pooling** mode, `MAX_CLIENT_CONN: 500`, `DEFAULT_POOL_SIZE: 20`
  - `scram-sha-256` auth with an `AUTH_QUERY` against `pg_shadow` (escaped as `$$1` so compose passes a literal `$1`)
  - Waits on the existing postgres healthcheck before starting
- `server` and `worker` now connect via `AUTHENTIK_POSTGRESQL__HOST: pgbouncer` instead of directly to `postgresql`
- Added `AUTHENTIK_POSTGRESQL__DISABLE_SERVER_SIDE_CURSORS: 'true'` to both — required for correctness when using transaction-mode pooling (server-side cursors don't survive connection reuse across transactions)
- Updated the README contents table

### Image bump (`e2153fc`)
- Default `AUTHENTIK_TAG` `2026.5.2` → `2026.5.4` (current latest release)

## Notes
- `server`/`worker` still `depends_on` postgres health only (matches the tested deployment); the `restart: unless-stopped` policy covers any startup race with pgbouncer.
- Validated with `docker compose config`.