### PR TITLE
feat(images): add Docker CE images (Debian 13 + Docker, NodeJS 24 + Docker)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -72,6 +72,34 @@ jobs:
             type=ref,event=tag
             type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
 
+      - name: Docker Meta (Docker)
+        id: meta-docker
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/docker
+          bake-target: docker
+          flavor: latest=false
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+
+      - name: Docker Meta (Docker + NodeJS)
+        id: meta-docker-nodejs
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/docker-nodejs
+          bake-target: docker-nodejs
+          flavor: latest=false
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+
       - name: Docker Meta (Docs)
         id: meta-docs
         uses: docker/metadata-action@v5
@@ -134,6 +162,8 @@ jobs:
             ./docker-bake.hcl
             ${{ steps.meta-base.outputs.bake-file }}
             ${{ steps.meta-nodejs.outputs.bake-file }}
+            ${{ steps.meta-docker.outputs.bake-file }}
+            ${{ steps.meta-docker-nodejs.outputs.bake-file }}
             ${{ steps.meta-docs.outputs.bake-file }}
             ${{ steps.meta-agent.outputs.bake-file }}
             ${{ steps.meta-manager.outputs.bake-file }}
@@ -143,6 +173,10 @@ jobs:
             base.cache-to=type=gha,mode=max,scope=base-${{ github.ref_name }}
             nodejs.cache-from=type=gha,scope=nodejs-${{ github.ref_name }}
             nodejs.cache-to=type=gha,mode=max,scope=nodejs-${{ github.ref_name }}
+            docker.cache-from=type=gha,scope=docker-${{ github.ref_name }}
+            docker.cache-to=type=gha,mode=max,scope=docker-${{ github.ref_name }}
+            docker-nodejs.cache-from=type=gha,scope=docker-nodejs-${{ github.ref_name }}
+            docker-nodejs.cache-to=type=gha,mode=max,scope=docker-nodejs-${{ github.ref_name }}
             docs.cache-from=type=gha,scope=docs-${{ github.ref_name }}
             docs.cache-to=type=gha,mode=max,scope=docs-${{ github.ref_name }}
             agent.cache-from=type=gha,scope=agent-${{ github.ref_name }}

--- a/create-a-container/client/src/pages/containers/ContainerFormPage.tsx
+++ b/create-a-container/client/src/pages/containers/ContainerFormPage.tsx
@@ -97,6 +97,8 @@ type FormData = z.infer<typeof schema>;
 const COMMON_TEMPLATES = [
   { value: 'ghcr.io/mieweb/opensource-server/base:latest', label: 'Debian 13' },
   { value: 'ghcr.io/mieweb/opensource-server/nodejs:latest', label: 'NodeJS 24' },
+  { value: 'ghcr.io/mieweb/opensource-server/docker:latest', label: 'Debian 13 + Docker' },
+  { value: 'ghcr.io/mieweb/opensource-server/docker-nodejs:latest', label: 'NodeJS 24 + Docker' },
   { value: 'ghcr.io/mieweb/ozwell-studio:latest', label: 'Ozwell Studio' },
 ];
 

--- a/images/docker-bake.hcl
+++ b/images/docker-bake.hcl
@@ -1,5 +1,5 @@
 group "default" {
-    targets = ["base", "nodejs", "docs", "agent", "manager", "proxmox-ve"]
+    targets = ["base", "nodejs", "docker", "docker-nodejs", "docs", "agent", "manager", "proxmox-ve"]
 }
 
 target "base" {
@@ -10,6 +10,24 @@ target "nodejs" {
     context = "./nodejs"
     contexts = {
         base = "target:base"
+    }
+}
+
+# Docker Engine (CE) on the plain Debian base. docker/Dockerfile builds FROM
+# the named `base` context, so the same Dockerfile also produces the
+# docker-nodejs image below by swapping that context.
+target "docker" {
+    context = "./docker"
+    contexts = {
+        base = "target:base"
+    }
+}
+
+# Docker Engine (CE) layered on the NodeJS image instead of the Debian base.
+target "docker-nodejs" {
+    context = "./docker"
+    contexts = {
+        base = "target:nodejs"
     }
 }
 

--- a/images/docker/Dockerfile
+++ b/images/docker/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+# Docker Engine (Community Edition) image.
+#
+# The `base` build context is a NAMED context supplied by docker-bake.hcl, so
+# this one Dockerfile produces two images:
+#   * target "docker"        - base = target:base   (Debian 13 + Docker)
+#   * target "docker-nodejs" - base = target:nodejs (NodeJS 24 + Docker)
+FROM base
+
+# Docker Engine (latest stable) from Docker's official APT repository.
+ARG DEBIAN_SUITE=trixie
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg \
+      | gpg --dearmor -o /usr/share/keyrings/docker.gpg && \
+    printf 'Types: deb\nURIs: https://download.docker.com/linux/debian\nSuites: %s\nComponents: stable\nSigned-By: /usr/share/keyrings/docker.gpg\n' "$DEBIAN_SUITE" \
+      > /etc/apt/sources.list.d/docker.sources && \
+    apt-get update && \
+    apt-get install -y \
+      docker-ce \
+      docker-ce-cli \
+      containerd.io \
+      docker-buildx-plugin \
+      docker-compose-plugin && \
+    systemctl enable docker.service docker.socket && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Give every LDAP user access to the Docker socket by making membership of
+# the LDAP `ldapusers` group imply membership of the local `docker` group.
+#
+# LDAP users cannot be listed in the local docker group (their memberships
+# come from LDAP via SSSD), so pam_group grants the docker group to their
+# sessions at login instead. The group.conf rule matches by NAME on both
+# sides - `%ldapusers` is resolved through NSS/SSSD exactly like the
+# `%ldapusers` sudoers rule in the base image - so no GID is hardcoded and
+# the stock docker.socket unit and docker group are left untouched. There is
+# also no boot-time ordering concern: resolution happens at login, when SSSD
+# is necessarily up (otherwise the LDAP user could not log in at all).
+#
+# pam_group is enabled via pam-auth-update (the same mechanism the base image
+# uses for mkhomedir) and acts during pam_setcred, which sshd applies to both
+# password and public-key logins.
+#
+# NOTE: access to the Docker socket is root-equivalent inside the container;
+# ldapusers already hold sudo here (see /etc/sudoers.d/ldapusers in the base
+# image), so this grants no privilege they don't already have.
+COPY --chmod=0644 pam-group /usr/share/pam-configs/pam-group
+RUN printf '\n# Members of the LDAP ldapusers group get the local docker group at login.\n*;*;%%ldapusers;Al0000-2400;docker\n' \
+      >> /etc/security/group.conf && \
+    pam-auth-update --enable pam-group

--- a/images/docker/pam-group
+++ b/images/docker/pam-group
@@ -1,0 +1,6 @@
+Name: Grant group memberships from /etc/security/group.conf (pam_group)
+Default: yes
+Priority: 0
+Auth-Type: Additional
+Auth:
+	optional			pam_group.so

--- a/mie-opensource-landing/docs/developers/docker-images.md
+++ b/mie-opensource-landing/docs/developers/docker-images.md
@@ -22,6 +22,18 @@ Extends base with Node.js 24 from NodeSource. Inherits LDAP authentication.
 
 **Registry:** `ghcr.io/mieweb/opensource-server/nodejs` · **Source:** [`images/nodejs/`](https://github.com/mieweb/opensource-server/tree/main/images/nodejs)
 
+### Debian 13 + Docker (`docker`)
+
+Extends base with Docker Engine (Community Edition) from Docker's official APT repository. Membership of the LDAP `ldapusers` group implies membership of the local `docker` group: a `pam_group` rule (`*;*;%ldapusers;Al0000-2400;docker` in `/etc/security/group.conf`) grants the `docker` group to LDAP users' sessions at login, matched by group name on both sides, so every LDAP user can use the Docker socket without per-user group management.
+
+**Registry:** `ghcr.io/mieweb/opensource-server/docker` · **Source:** [`images/docker/`](https://github.com/mieweb/opensource-server/tree/main/images/docker)
+
+### NodeJS 24 + Docker (`docker-nodejs`)
+
+The same Dockerfile as `docker`, built on top of the `nodejs` image instead of the Debian base (the bake target swaps the named `base` build context). Inherits Node.js 24 and LDAP authentication.
+
+**Registry:** `ghcr.io/mieweb/opensource-server/docker-nodejs` · **Source:** [`images/docker/`](https://github.com/mieweb/opensource-server/tree/main/images/docker)
+
 ### Agent (`agent`)
 
 Extends nodejs with the `opensource-agent` package (pull-config, nginx with ModSecurity/OWASP CRS, dnsmasq) and [acme.sh](https://github.com/acmesh-official/acme.sh) for ACME certificate management. Used as the networking layer for each site — handles reverse proxy, DNS, and TLS. See [Deploying Agents](../admins/deploying-agents.md).

--- a/mie-opensource-landing/docs/users/creating-containers/web-gui.md
+++ b/mie-opensource-landing/docs/users/creating-containers/web-gui.md
@@ -32,6 +32,8 @@ Select a standard image or choose "Custom Docker Image..." for any registry imag
 
 - **Debian 13**: `ghcr.io/mieweb/opensource-server/base:latest`
 - **NodeJS 24**: `ghcr.io/mieweb/opensource-server/nodejs:latest`
+- **Debian 13 + Docker**: `ghcr.io/mieweb/opensource-server/docker:latest` — Docker Engine (CE); every LDAP user can use the Docker socket
+- **NodeJS 24 + Docker**: `ghcr.io/mieweb/opensource-server/docker-nodejs:latest`
 - **Custom**: Full registry path (e.g., `docker.io/library/nginx:latest`)
 
 ### Services (Optional)


### PR DESCRIPTION
## Summary

Alternative approach to #406: instead of making rootless podman work in guest containers, ship images with the official Docker Engine (CE) preinstalled and grant every LDAP user access to the Docker socket.

- **`images/docker/`** — new Dockerfile installing Docker Engine (CE), CLI, containerd, buildx and compose plugins from Docker's official APT repository. `docker.service`/`docker.socket` are enabled at build time.
- **One Dockerfile, two images** — the `base` build context is a *named context* supplied by bake, so:
  - target `docker` (`base = target:base`) → **Debian 13 + Docker**
  - target `docker-nodejs` (`base = target:nodejs`) → **NodeJS 24 + Docker**
- **LDAP socket access** — membership of the LDAP `ldapusers` group implies membership of the local `docker` group via `pam_group`: the rule `*;*;%ldapusers;Al0000-2400;docker` in `/etc/security/group.conf` grants the `docker` group to LDAP users' sessions at login. Both sides are matched by group **name** (`%ldapusers` resolves through NSS/SSSD exactly like the `%ldapusers` sudoers rule in the base image), so no GID is hardcoded, no local group is created, and the stock `docker.socket` unit and `docker` group are untouched. Resolution happens at login time, when SSSD is necessarily up, so there is no boot-ordering concern. `pam_group` is enabled via `pam-auth-update` (same mechanism as `mkhomedir` in base) and acts during `pam_setcred`, which sshd applies to both password and public-key logins. Socket access is root-equivalent, but ldapusers already hold sudo in these containers (`/etc/sudoers.d/ldapusers` in base), so no new privilege is granted.
- **CI** — both targets added to `docker-bake.hcl` (`default` group) and `build-images.yml` (metadata steps, bake files, GHA cache scopes), publishing `ghcr.io/mieweb/opensource-server/docker` and `.../docker-nodejs` with the same tag rules as base/nodejs.
- **UI** — new template entries in `ContainerFormPage.tsx`: `Debian 13 + Docker` and `NodeJS 24 + Docker`.
- **Docs** — `web-gui.md` template list and `docker-images.md` image reference updated.

## Validation

- `docker buildx bake --print default` resolves both new targets with the expected contexts (`docker → target:base`, `docker-nodejs → target:nodejs`)
- Workflow YAML parses
- `%group` syntax in the `users` field confirmed against `group.conf(5)`

## Notes for review/testing

- dockerd inside an LXC guest requires nesting to be enabled on the Proxmox side.
- Docker version is intentionally unpinned (latest stable from the trixie channel of download.docker.com).
- To verify in a running container: log in over SSH as an LDAP user and check `id` shows `docker`, then `docker ps`.