### PR TITLE
feat(containers): mount shared read-only volume into created containers

### DIFF
--- a/create-a-container/bin/create-container.js
+++ b/create-a-container/bin/create-container.js
@@ -92,6 +92,28 @@ async function resolveStorage(client, nodeName, preferred, contentType) {
 }
 
 /**
+ * Build the mp0 mount point value for the shared read-only volume.
+ * Assumes the node's template storage is a directory storage mounted at
+ * /mnt/pve/<storage> (i.e. container templates are downloaded to
+ * /mnt/pve/<storage>/template/cache), so shared volumes live at
+ * /mnt/pve/<storage>/volumes/<name>.
+ *
+ * TODO(#421): Replace this hardcoded 'quick_and_dirty' volume with a proper
+ * feature where users can define their own volumes and attach them with
+ * per-volume permissions (read-only/read-write). The host path should be
+ * derived from the storage's actual configured path instead of assuming the
+ * /mnt/pve/<storage> layout. See:
+ * https://github.com/mieweb/opensource-server/issues/421
+ *
+ * @param {string} templateStorage - Resolved template storage name for the node
+ * @returns {string} Proxmox mp0 config value (bind mount, read-only)
+ */
+function buildSharedVolumeMp0(templateStorage) {
+  const volumeName = 'quick_and_dirty';
+  return `/mnt/pve/${templateStorage}/volumes/${volumeName},mp=/mnt/${volumeName},ro=1`;
+}
+
+/**
  * Setup ACL for container owner
  * Grants PVEVMUser role to username@ldap on /vms/{vmid}
  * Non-blocking: logs errors but continues on failure
@@ -305,7 +327,9 @@ async function main() {
         onboot: 1,
         tags: container.username,
         unprivileged: 1,
-        rootfs: `${rootfsStorage}:${rootfsSize}`
+        rootfs: `${rootfsStorage}:${rootfsSize}`,
+        // TODO(#421): hardcoded shared volume; see buildSharedVolumeMp0()
+        mp0: buildSharedVolumeMp0(templateStorage)
       });
       console.log(`Create task started: ${createUpid}`);
 
@@ -339,6 +363,17 @@ async function main() {
       const rootfsStorage = await resolveStorage(client, node.name, node.volumeStorage || 'local-lvm', 'rootdir');
       console.log(`Using rootfs storage: ${rootfsStorage}`);
       
+      // Resolve the template storage to locate the shared volume mount (mp0).
+      // Non-fatal: cloning does not otherwise require a template storage.
+      // TODO(#421): hardcoded shared volume; see buildSharedVolumeMp0()
+      let mp0 = null;
+      try {
+        const templateStorage = await resolveStorage(client, node.name, node.imageStorage || 'local', 'vztmpl');
+        mp0 = buildSharedVolumeMp0(templateStorage);
+      } catch (err) {
+        console.warn(`Skipping shared volume mount (mp0): ${err.message}`);
+      }
+      
       // Clone the template
       console.log(`Cloning template ${templateVmid} to VMID ${vmid}...`);
       const cloneUpid = await client.cloneLxc(node.name, templateVmid, vmid, {
@@ -363,7 +398,8 @@ async function main() {
         searchdomain: site.internalDomain,
         swap,
         onboot: 1,
-        tags: container.username
+        tags: container.username,
+        ...(mp0 ? { mp0 } : {})
       });
       console.log('Container configured');
     }


### PR DESCRIPTION
## Summary

Adds an `mp0` mount point to every created container: `/mnt/pve/<templateStorage>/volumes/quick_and_dirty` is bind-mounted read-only at `/mnt/quick_and_dirty`.

The host path is derived from the node's resolved template storage, assuming the storage is mounted at `/mnt/pve/<storage>` (i.e. container templates are downloaded to `/mnt/pve/<storage>/template/cache`), so shared volumes live at `/mnt/pve/<storage>/volumes/<name>`.

This is an intentional stopgap: the volume name is hardcoded to `quick_and_dirty`. #421 tracks turning this into a proper feature where users can define their own volumes with per-volume permissions; a `TODO(#421)` is left on the new `buildSharedVolumeMp0()` helper.

## Changes

- New `buildSharedVolumeMp0(templateStorage)` helper in `create-a-container/bin/create-container.js` building the mp0 value (`/mnt/pve/<storage>/volumes/quick_and_dirty,mp=/mnt/quick_and_dirty,ro=1`)
- **OCI image path**: `mp0` added to the `createLxc` options, reusing the already-resolved template storage
- **Template clone path**: template storage is now resolved in this branch too (non-fatal — if no `vztmpl`-capable storage exists, the mount is skipped with a warning instead of failing creation, since cloning doesn't otherwise need one) and `mp0` is applied via the post-clone `updateLxcConfig` call

## Notes

- Proxmox restricts raw bind mounts (`mp0` with a host path) to `root@pam`, so the manager's API credentials must allow this
- Docker nodes silently ignore the option (the Docker backend's `createLxc` only maps known fields), so Docker containers won't get the mount — noted in #421

## Testing

- `node --check create-a-container/bin/create-container.js` passes (no backend test suite exists for these job scripts)

Refs #421