### PR TITLE
fix(create-a-container): raise default container maxmem to 8GB

### DIFF
--- a/create-a-container/bin/create-container.js
+++ b/create-a-container/bin/create-container.js
@@ -243,10 +243,11 @@ async function main() {
     container.hostname,
     container.username,
   );
-  const cores = approvedResources.cpus || 4;
-  const memory = approvedResources.memory || 4096;
-  const swap = approvedResources.swap || 0;
-  const rootfsSize = approvedResources.rootfs || 50;
+  const { RESOURCE_DEFAULTS } = ResourceRequest;
+  const cores = approvedResources.cpus || RESOURCE_DEFAULTS.cpus;
+  const memory = approvedResources.memory || RESOURCE_DEFAULTS.memory;
+  const swap = approvedResources.swap || RESOURCE_DEFAULTS.swap;
+  const rootfsSize = approvedResources.rootfs || RESOURCE_DEFAULTS.rootfs;
   console.log(`Resources: cores=${cores}, memory=${memory}MB, swap=${swap}MB, rootfs=${rootfsSize}GB`);
 
   const isDocker = isDockerImage(container.template);

--- a/create-a-container/client/src/components/containers/ResourcesSection.tsx
+++ b/create-a-container/client/src/components/containers/ResourcesSection.tsx
@@ -46,7 +46,7 @@ const RESOURCE_OPTIONS = [
   },
 ] as const;
 
-const DEFAULTS: EffectiveResources = { memory: 4096, swap: 0, cpus: 4, rootfs: 50 };
+const DEFAULTS: EffectiveResources = { memory: 8192, swap: 0, cpus: 4, rootfs: 50 };
 
 interface ResourcesSectionProps {
   siteId: string;

--- a/create-a-container/client/src/pages/resource-requests/MyRequestsPage.tsx
+++ b/create-a-container/client/src/pages/resource-requests/MyRequestsPage.tsx
@@ -23,7 +23,7 @@ const RESOURCE_LABELS: Record<string, string> = {
 };
 
 const RESOURCE_DEFAULTS: Record<string, number> = {
-  memory: 4096,
+  memory: 8192,
   swap: 0,
   cpus: 4,
   rootfs: 50,

--- a/create-a-container/client/src/pages/resource-requests/ResourceRequestsPage.tsx
+++ b/create-a-container/client/src/pages/resource-requests/ResourceRequestsPage.tsx
@@ -29,7 +29,7 @@ const RESOURCE_LABELS: Record<string, string> = {
 };
 
 const RESOURCE_DEFAULTS: Record<string, number> = {
-  memory: 4096,
+  memory: 8192,
   swap: 0,
   cpus: 4,
   rootfs: 50,

--- a/create-a-container/models/resourcerequest.js
+++ b/create-a-container/models/resourcerequest.js
@@ -7,7 +7,7 @@ const { Model } = require('sequelize');
  * Requests at or below these values are auto-approved for non-admin users.
  */
 const RESOURCE_DEFAULTS = {
-  memory: 4096,   // MB
+  memory: 8192,   // MB
   swap: 0,        // MB
   cpus: 4,
   rootfs: 50,     // GB

--- a/create-a-container/utils/dummy-api.js
+++ b/create-a-container/utils/dummy-api.js
@@ -69,7 +69,7 @@ class DummyApi {
       cfg = {
         net0: `name=eth0,hwaddr=${DummyApi._fakeMac()},ip=dhcp,bridge=${this.node.networkBridge || 'vmbr0'}`,
         cores: 4,
-        memory: 4096,
+        memory: 8192,
         rootfs: `local:vm-${vmid}-disk-0,size=50G`,
       };
       this.configs.set(vmid, cfg);


### PR DESCRIPTION
Closes #432. Part of #431 (memory-exhaustion thrash).

## Problem
Interactive dev boxes (code-server + extension host + a Vite dev server) realistically need ~6GB. The default of 4GB was too tight and was the root cause in #431: a container held ~3.6GB of unswappable anon memory in a 4GB container, thrashing against its cgroup limit while nodes had ample headroom.

## Changes
**Server (behavioral):**
- `models/resourcerequest.js` — `RESOURCE_DEFAULTS.memory: 4096 → 8192`. This is the canonical default; it feeds the `/api/v1/resource-requests/effective` endpoint and the auto-approval threshold (requests ≤ default are auto-approved).
- `bin/create-container.js` — sourced the creation-time fallbacks (`cores`/`memory`/`swap`/`rootfs`) from `RESOURCE_DEFAULTS` instead of hardcoded literals, so the default lives in one place. `memory` flows into `createLxc` (Docker-image path) and `updateLxcConfig` after `cloneLxc` (template path).

**Consistency mirrors:**
- `utils/dummy-api.js` — dummy node seed `memory: 8192`
- `client/src/components/containers/ResourcesSection.tsx` — UI fallback `DEFAULTS.memory: 8192`
- `client/src/pages/resource-requests/{ResourceRequestsPage,MyRequestsPage}.tsx` — display defaults `8192`

## Acceptance criteria
- [x] New containers are created with 8GB maxmem by default
- [x] Existing per-template/user overrides still work (`approvedResources` takes precedence over defaults)
- [x] No node modification required — Proxmox REST API config value only (`proxmox-api.js` has no defaults; untouched)

## Notes
- `swap` still defaults to `0` — intentionally out of scope.
- All edited JS files pass `node --check`. `node_modules` is not installed in this environment, so jest/vite were not run here; the client edits are single-literal swaps that don't affect types.