### PR TITLE
fix(agent): allow DHCP on isolated sites without gateway or DNS forwarders

### DIFF
--- a/agent/src/apply.ts
+++ b/agent/src/apply.ts
@@ -63,10 +63,9 @@ export const services: ManagedService[] = [
     unit: 'dnsmasq',
     async render(config) {
       const site = config.site;
-      // Skip dnsmasq management until the site's DHCP/DNS settings are fully
-      // configured — the templates need all of these fields.
-      if (!site?.internalDomain || !site.dhcpRange || !site.subnetMask
-        || !site.gateway || !site.dnsForwarders) {
+      // DHCP and internal DNS can run on an isolated site. Only the core
+      // DHCP settings are required; gateway and DNS forwarders are optional.
+      if (!site?.internalDomain || !site.dhcpRange || !site.subnetMask) {
         return null;
       }
       const data = { site };

--- a/agent/templates/dnsmasq/dhcp-opts.ejs
+++ b/agent/templates/dnsmasq/dhcp-opts.ejs
@@ -1,1 +1,1 @@
-option:router,<%= site.gateway %>
+<%_ if (site.gateway) { _%>option:router,<%= site.gateway %><%_ } else { _%>option:router<%_ } _%>

--- a/agent/templates/dnsmasq/servers.ejs
+++ b/agent/templates/dnsmasq/servers.ejs
@@ -1,3 +1,3 @@
-<%_ site.dnsForwarders.split(',').forEach((forwarder) => { _%>
-server=<%= forwarder.trim() %>
+<%_ (site.dnsForwarders || '').split(',').map((forwarder) => forwarder.trim()).filter(Boolean).forEach((forwarder) => { _%>
+server=<%= forwarder %>
 <%_ }) _%>


### PR DESCRIPTION
## Summary

- Allow dnsmasq configuration to be applied when the site has an internal domain, DHCP range, and subnet mask, without requiring a gateway or DNS forwarders.
- Suppress the DHCP router option when no gateway is configured.
- Allow the dnsmasq servers file to remain empty when no DNS forwarders are configured.

## Testing

- `npm ci`
- `npm run build`
- `git diff --check`
- End-to-end DHCP validation on an isolated Proxmox site remains to be completed.

## Related Issue

Fixes #455